### PR TITLE
Avoid leaking plugin libraries when unload symbol is missing

### DIFF
--- a/Engine/Source/Tbx/PluginAPI/LoadedPlugin.cpp
+++ b/Engine/Source/Tbx/PluginAPI/LoadedPlugin.cpp
@@ -60,6 +60,9 @@ namespace Tbx
         if (!_library.GetSymbol("Unload"))
         {
             TBX_TRACE_ERROR("No unload library function found in: {0}, is it calling TBX_REGISTER_PLUGIN?", pluginFullPath);
+            // Since we already loaded the library we must unload it here to
+            // avoid leaking the library handle and associated resources.
+            _library.Unload();
             return;
         }
 


### PR DESCRIPTION
## Summary
- unload dynamic library if required unload function is absent to prevent resource leaks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68afe9cbdf548327ad0c2d0a067cd0b7