### PR TITLE
Add math operations for Vector2 and Vector2I

### DIFF
--- a/Engine/Include/Tbx/Math/Vectors.h
+++ b/Engine/Include/Tbx/Math/Vectors.h
@@ -58,8 +58,6 @@ namespace Tbx
         float Z = 0;
     };
 
-    // TODO: implement +, -, *, / operators for Vector2 and Vector2I
-
     /// <summary>
     /// Represents a position, scale, or direction in 2d space. X, Y are stored as euler angles.
     /// </summary>
@@ -71,7 +69,36 @@ namespace Tbx
         Vector2(float x, float y) : X(x), Y(y) {}
         explicit(false) Vector2(const Vector3& vector) : X(vector.X), Y(vector.Y) {}
 
+        friend Vector2 operator + (const Vector2& lhs, const Vector2& rhs) { return Add(lhs, rhs); }
+        friend Vector2 operator - (const Vector2& lhs, const Vector2& rhs) { return Subtract(lhs, rhs); }
+        friend Vector2 operator * (const Vector2& lhs, const Vector2& rhs) { return Multiply(lhs, rhs); }
+        friend Vector2 operator * (const Vector2& lhs, float scalar) { return Multiply(lhs, scalar); }
+
+        Vector2& operator += (const Vector2& other);
+        Vector2& operator -= (const Vector2& other);
+        Vector2& operator *= (const Vector2& other);
+        Vector2& operator *= (float other);
+
         std::string ToString() const;
+
+        /// <summary>
+        /// Returns true if the vector is nearly zero in all components
+        /// </summary>
+        bool IsNearlyZero(float tolerance = 1e-6f) const;
+
+        Vector2 Normalize() const { return Normalize(*this); }
+        Vector2 Add(const Vector2& rhs) const { return Add(*this, rhs); }
+        Vector2 Subtract(const Vector2& rhs) const { return Subtract(*this, rhs); }
+        Vector2 Multiply(const Vector2& rhs) const { return Multiply(*this, rhs); }
+        Vector2 Multiply(float scalar) const { return Multiply(*this, scalar); }
+        float Dot(const Vector2& rhs) const { return Dot(*this, rhs); }
+
+        static Vector2 Normalize(const Vector2& vector);
+        static Vector2 Add(const Vector2& lhs, const Vector2& rhs);
+        static Vector2 Subtract(const Vector2& lhs, const Vector2& rhs);
+        static Vector2 Multiply(const Vector2& lhs, const Vector2& rhs);
+        static Vector2 Multiply(const Vector2& lhs, float scalar);
+        static float Dot(const Vector2& lhs, const Vector2& rhs);
 
         float X = 0;
         float Y = 0;
@@ -89,7 +116,36 @@ namespace Tbx
         explicit(false) Vector2I(const Vector3& vector) : X(static_cast<int>(vector.X)), Y(static_cast<int>(vector.Y)) {}
         Vector2I(int x, int y) : X(x), Y(y) {}
 
+        friend Vector2I operator + (const Vector2I& lhs, const Vector2I& rhs) { return Add(lhs, rhs); }
+        friend Vector2I operator - (const Vector2I& lhs, const Vector2I& rhs) { return Subtract(lhs, rhs); }
+        friend Vector2I operator * (const Vector2I& lhs, const Vector2I& rhs) { return Multiply(lhs, rhs); }
+        friend Vector2I operator * (const Vector2I& lhs, int scalar) { return Multiply(lhs, scalar); }
+
+        Vector2I& operator += (const Vector2I& other);
+        Vector2I& operator -= (const Vector2I& other);
+        Vector2I& operator *= (const Vector2I& other);
+        Vector2I& operator *= (int other);
+
         std::string ToString() const;
+
+        /// <summary>
+        /// Returns true if the vector is nearly zero in all components
+        /// </summary>
+        bool IsNearlyZero(int tolerance = 0) const;
+
+        Vector2I Normalize() const { return Normalize(*this); }
+        Vector2I Add(const Vector2I& rhs) const { return Add(*this, rhs); }
+        Vector2I Subtract(const Vector2I& rhs) const { return Subtract(*this, rhs); }
+        Vector2I Multiply(const Vector2I& rhs) const { return Multiply(*this, rhs); }
+        Vector2I Multiply(int scalar) const { return Multiply(*this, scalar); }
+        int Dot(const Vector2I& rhs) const { return Dot(*this, rhs); }
+
+        static Vector2I Normalize(const Vector2I& vector);
+        static Vector2I Add(const Vector2I& lhs, const Vector2I& rhs);
+        static Vector2I Subtract(const Vector2I& lhs, const Vector2I& rhs);
+        static Vector2I Multiply(const Vector2I& lhs, const Vector2I& rhs);
+        static Vector2I Multiply(const Vector2I& lhs, int scalar);
+        static int Dot(const Vector2I& lhs, const Vector2I& rhs);
 
         int X = 0;
         int Y = 0;

--- a/Engine/Source/Tbx/Math/Vectors.cpp
+++ b/Engine/Source/Tbx/Math/Vectors.cpp
@@ -121,13 +121,181 @@ namespace Tbx
         return result;
     }
 
+    Vector2& Vector2::operator+=(const Vector2& other)
+    {
+        X += other.X;
+        Y += other.Y;
+        return *this;
+    }
+
+    Vector2& Vector2::operator-=(const Vector2& other)
+    {
+        X -= other.X;
+        Y -= other.Y;
+        return *this;
+    }
+
+    Vector2& Vector2::operator*=(const Vector2& other)
+    {
+        X *= other.X;
+        Y *= other.Y;
+        return *this;
+    }
+
+    Vector2& Vector2::operator*=(float other)
+    {
+        X *= other;
+        Y *= other;
+        return *this;
+    }
+
     std::string Vector2::ToString() const
     {
         return std::format("({}, {})", X, Y);
     }
 
+    bool Vector2::IsNearlyZero(float tolerance) const
+    {
+        return glm::abs(X) < tolerance &&
+            glm::abs(Y) < tolerance;
+    }
+
+    Vector2 Vector2::Normalize(const Vector2& vector)
+    {
+        const auto& glmVec = glm::vec2(vector.X, vector.Y);
+        const auto& result = glm::normalize(glmVec);
+        return { result.x, result.y };
+    }
+
+    Vector2 Vector2::Add(const Vector2& lhs, const Vector2& rhs)
+    {
+        const auto& glmVecL = glm::vec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::vec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL + glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2 Vector2::Subtract(const Vector2& lhs, const Vector2& rhs)
+    {
+        const auto& glmVecL = glm::vec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::vec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL - glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2 Vector2::Multiply(const Vector2& lhs, const Vector2& rhs)
+    {
+        const auto& glmVecL = glm::vec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::vec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL * glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2 Vector2::Multiply(const Vector2& lhs, float scalar)
+    {
+        const auto& glmVecL = glm::vec2(lhs.X, lhs.Y);
+        const auto& result = glmVecL * scalar;
+        return { result.x, result.y };
+    }
+
+    float Vector2::Dot(const Vector2& lhs, const Vector2& rhs)
+    {
+        const auto& glmVecL = glm::vec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::vec2(rhs.X, rhs.Y);
+
+        const auto& result = glm::dot(glmVecL, glmVecR);
+        return result;
+    }
+
+    Vector2I& Vector2I::operator+=(const Vector2I& other)
+    {
+        X += other.X;
+        Y += other.Y;
+        return *this;
+    }
+
+    Vector2I& Vector2I::operator-=(const Vector2I& other)
+    {
+        X -= other.X;
+        Y -= other.Y;
+        return *this;
+    }
+
+    Vector2I& Vector2I::operator*=(const Vector2I& other)
+    {
+        X *= other.X;
+        Y *= other.Y;
+        return *this;
+    }
+
+    Vector2I& Vector2I::operator*=(int other)
+    {
+        X *= other;
+        Y *= other;
+        return *this;
+    }
+
     std::string Vector2I::ToString() const
     {
         return std::format("({}, {})", X, Y);
+    }
+
+    bool Vector2I::IsNearlyZero(int tolerance) const
+    {
+        return glm::abs(X) <= tolerance &&
+            glm::abs(Y) <= tolerance;
+    }
+
+    Vector2I Vector2I::Normalize(const Vector2I& vector)
+    {
+        const auto& glmVec = glm::vec2(static_cast<float>(vector.X), static_cast<float>(vector.Y));
+        const auto& result = glm::normalize(glmVec);
+        return { static_cast<int>(result.x), static_cast<int>(result.y) };
+    }
+
+    Vector2I Vector2I::Add(const Vector2I& lhs, const Vector2I& rhs)
+    {
+        const auto& glmVecL = glm::ivec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::ivec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL + glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2I Vector2I::Subtract(const Vector2I& lhs, const Vector2I& rhs)
+    {
+        const auto& glmVecL = glm::ivec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::ivec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL - glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2I Vector2I::Multiply(const Vector2I& lhs, const Vector2I& rhs)
+    {
+        const auto& glmVecL = glm::ivec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::ivec2(rhs.X, rhs.Y);
+
+        const auto& result = glmVecL * glmVecR;
+        return { result.x, result.y };
+    }
+
+    Vector2I Vector2I::Multiply(const Vector2I& lhs, int scalar)
+    {
+        const auto& glmVecL = glm::ivec2(lhs.X, lhs.Y);
+        const auto& result = glmVecL * scalar;
+        return { result.x, result.y };
+    }
+
+    int Vector2I::Dot(const Vector2I& lhs, const Vector2I& rhs)
+    {
+        const auto& glmVecL = glm::ivec2(lhs.X, lhs.Y);
+        const auto& glmVecR = glm::ivec2(rhs.X, rhs.Y);
+
+        const auto& result = glm::dot(glmVecL, glmVecR);
+        return result;
     }
 }

--- a/Engine/Tests/Math/VectorTests.cpp
+++ b/Engine/Tests/Math/VectorTests.cpp
@@ -126,6 +126,86 @@ namespace Tbx::Tests::Math
         EXPECT_FLOAT_EQ(v.Y, 0);
     }
 
+    TEST(Vector2Tests, ToString_ProducesFormattedOutput)
+    {
+        // Arrange
+        Vector2 v(1.0f, 2.0f);
+
+        // Act
+        std::string str = v.ToString();
+
+        // Assert
+        EXPECT_EQ(str, "(1, 2)");
+    }
+
+    TEST(Vector2Tests, OperatorAdd_AddsTwoVectors)
+    {
+        // Arrange
+        Vector2 a(1, 2);
+        Vector2 b(4, 5);
+
+        // Act
+        Vector2 result = a + b;
+
+        // Assert
+        EXPECT_FLOAT_EQ(result.X, 5);
+        EXPECT_FLOAT_EQ(result.Y, 7);
+    }
+
+    TEST(Vector2Tests, OperatorSubtract_SubtractsTwoVectors)
+    {
+        // Arrange
+        Vector2 a(4, 5);
+        Vector2 b(1, 2);
+
+        // Act
+        Vector2 result = a - b;
+
+        // Assert
+        EXPECT_FLOAT_EQ(result.X, 3);
+        EXPECT_FLOAT_EQ(result.Y, 3);
+    }
+
+    TEST(Vector2Tests, OperatorMultiply_MultipliesTwoVectorsComponentWise)
+    {
+        // Arrange
+        Vector2 a(2, 3);
+        Vector2 b(5, 6);
+
+        // Act
+        Vector2 result = a * b;
+
+        // Assert
+        EXPECT_FLOAT_EQ(result.X, 10);
+        EXPECT_FLOAT_EQ(result.Y, 18);
+    }
+
+    TEST(Vector2Tests, Normalize_ReturnsNormalizedVector)
+    {
+        // Arrange
+        Vector2 v(3, 4);
+
+        // Act
+        Vector2 result = Vector2::Normalize(v);
+
+        // Assert
+        EXPECT_NEAR(result.X, 0.6f, 1e-5f);
+        EXPECT_NEAR(result.Y, 0.8f, 1e-5f);
+    }
+
+    TEST(Vector2Tests, Dot_ReturnsDotProduct)
+    {
+        // Arrange
+        Vector2 a(1, 2);
+        Vector2 b(4, -5);
+
+        // Act
+        float dot = Vector2::Dot(a, b);
+
+        // Assert
+        EXPECT_FLOAT_EQ(dot, -6); // 1*4 + 2*(-5) = -6
+    }
+
     TEST(Vector2ITests, Constructor_FromVector3_CastsAndCopiesXY)
     {
         // Arrange
@@ -147,5 +227,72 @@ namespace Tbx::Tests::Math
         // Assert
         EXPECT_EQ(v.X, 1);
         EXPECT_EQ(v.Y, 1);
+    }
+
+    TEST(Vector2ITests, ToString_ProducesFormattedOutput)
+    {
+        // Arrange
+        Vector2I v(1, 2);
+
+        // Act
+        std::string str = v.ToString();
+
+        // Assert
+        EXPECT_EQ(str, "(1, 2)");
+    }
+
+    TEST(Vector2ITests, OperatorAdd_AddsTwoVectors)
+    {
+        // Arrange
+        Vector2I a(1, 2);
+        Vector2I b(4, 5);
+
+        // Act
+        Vector2I result = a + b;
+
+        // Assert
+        EXPECT_EQ(result.X, 5);
+        EXPECT_EQ(result.Y, 7);
+    }
+
+    TEST(Vector2ITests, OperatorSubtract_SubtractsTwoVectors)
+    {
+        // Arrange
+        Vector2I a(4, 5);
+        Vector2I b(1, 2);
+
+        // Act
+        Vector2I result = a - b;
+
+        // Assert
+        EXPECT_EQ(result.X, 3);
+        EXPECT_EQ(result.Y, 3);
+    }
+
+    TEST(Vector2ITests, OperatorMultiply_MultipliesTwoVectorsComponentWise)
+    {
+        // Arrange
+        Vector2I a(2, 3);
+        Vector2I b(5, 6);
+
+        // Act
+        Vector2I result = a * b;
+
+        // Assert
+        EXPECT_EQ(result.X, 10);
+        EXPECT_EQ(result.Y, 18);
+    }
+
+    TEST(Vector2ITests, Dot_ReturnsDotProduct)
+    {
+        // Arrange
+        Vector2I a(1, 2);
+        Vector2I b(4, -5);
+
+        // Act
+        int dot = Vector2I::Dot(a, b);
+
+        // Assert
+        EXPECT_EQ(dot, -6); // 1*4 + 2*(-5) = -6
     }
 }


### PR DESCRIPTION
## Summary
- mirror Vector3 math operations on Vector2 and Vector2I
- cover new vector features with tests for arithmetic, normalization, and dot product

## Testing
- `g++ -std=c++20 -IEngine/Include -IEngine/Tests -IDependencies/googletest/googletest/include -IDependencies/googletest/googletest -IDependencies/glm -pthread Engine/Tests/Math/VectorTests.cpp Engine/Source/Tbx/Math/Vectors.cpp Dependencies/googletest/googletest/src/gtest_main.cc Dependencies/googletest/googletest/src/gtest-all.cc -o vector_tests` *(fails: fatal error: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6705d30908327b821d84c923805b5