### PR TITLE
Fix Windows CI build by disabling spdlog tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,9 @@ set(IMGUI_PLATFORM   SDL3    CACHE STRING "" FORCE)
 set(IMGUI_RENDERER   OpenGL3 CACHE STRING "" FORCE)
 set(IMGUI_GL_LOADER  GLAD    CACHE STRING "" FORCE)
 set(IMGUI_BUILD_DEMO OFF     CACHE BOOL   "" FORCE)
+# Disable building of spdlog tests to avoid warnings treated as errors on MSVC
+set(SPDLOG_BUILD_TESTS OFF   CACHE BOOL   "" FORCE)
+set(SPDLOG_BUILD_EXAMPLES OFF CACHE BOOL  "" FORCE)
 
 # Dependencies
 add_subdirectory(Dependencies/glad)


### PR DESCRIPTION
## Summary
- Disable building spdlog's tests and examples to avoid MSVC random_shuffle warnings that break Windows CI

## Testing
- `git submodule update --init --recursive --depth 1` *(failed: CONNECT tunnel failed, response 403)*
- `cmake -S . -B build` *(failed: The source directory ... does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1bff2570832784ee45532faced68