### PR TITLE
Disable spdlog unit tests to fix Windows build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(IMGUI_GL_LOADER  GLAD    CACHE STRING "" FORCE)
 set(IMGUI_BUILD_DEMO OFF     CACHE BOOL   "" FORCE)
 # Disable building of spdlog tests to avoid warnings treated as errors on MSVC
 set(SPDLOG_BUILD_TESTS OFF   CACHE BOOL   "" FORCE)
+set(SPDLOG_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
 set(SPDLOG_BUILD_EXAMPLES OFF CACHE BOOL  "" FORCE)
 
 # Dependencies


### PR DESCRIPTION
## Summary
- Disable spdlog unit tests across versions to avoid warnings treated as errors

------
https://chatgpt.com/codex/tasks/task_e_68ba26efc6d08327bb17a2a61a6ad2e6