### PR TITLE
Fix unresolved main in tests by linking gtest_main

### DIFF
--- a/Engine/Tests/CMakeLists.txt
+++ b/Engine/Tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set_target_properties(Engine PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED YE
 target_link_libraries(Tests PRIVATE
     Engine
     gtest
+    gtest_main
     gmock
 )
 


### PR DESCRIPTION
## Summary
- link gtest_main library for the Tests target so gtest supplies `main`

## Testing
- `cmake -S . -B build` *(fails: Dependencies/... does not contain a CMakeLists.txt)*
- `git submodule update --init --recursive` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3a6657a483279931426d78815cde