### PR TITLE
Install X11 dependencies on Linux CI

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -49,6 +49,12 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev
+
     - name: Set reusable strings
       # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
       id: strings


### PR DESCRIPTION
## Summary
- install xorg and wayland development libraries on Linux builds so SDL can create windows


------
https://chatgpt.com/codex/tasks/task_e_68ba3e9d319c8327b3406c784acbf139