### PR TITLE
Ensure submodules are initialized on Ubuntu workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -47,7 +47,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        submodules: 'recursive'
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Initialize submodules
+      if: runner.os == 'Linux'
+      run: git submodule update --init --recursive
 
     - name: Install dependencies
       if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- checkout repository with full history
- initialize submodules explicitly for Linux runners

## Testing
- `python - <<'PY'
import yaml,sys
with open('.github/workflows/cmake-multi-platform.yml') as f:
    yaml.safe_load(f)
print('YAML OK')
PY` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Cannot connect to proxy - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba411b36808327bc3e1cc10d30bc8a