### PR TITLE
chore: auto assign new issues

### DIFF
--- a/.github/workflows/auto-assign-issues.yml
+++ b/.github/workflows/auto-assign-issues.yml
@@ -1,0 +1,24 @@
+name: Auto assign issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Assign issue to author
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const issue = context.payload.issue
+          github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issue.number,
+            assignees: [issue.user.login],
+          })


### PR DESCRIPTION
## Summary
- auto-assign newly opened issues to their author

------
https://chatgpt.com/codex/tasks/task_e_68ba42102f108327b398ff0ac81c8eba