### PR TITLE
Fix CMake matrix configuration for Ubuntu workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -21,26 +21,22 @@ jobs:
       # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        build_type: [Release]
-        c_compiler: [gcc, clang, cl]
         include:
+          # Windows build using MSVC
           - os: windows-latest
+            build_type: Release
             c_compiler: cl
             cpp_compiler: cl
+          # Linux build using GCC
           - os: ubuntu-latest
+            build_type: Release
             c_compiler: gcc
             cpp_compiler: g++
+          # Linux build using Clang
           - os: ubuntu-latest
+            build_type: Release
             c_compiler: clang
             cpp_compiler: clang++
-        exclude:
-          - os: windows-latest
-            c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
-          - os: ubuntu-latest
-            c_compiler: cl
 
     steps:
 


### PR DESCRIPTION
## Summary
- restructure CMake workflow matrix to explicitly map C and C++ compilers per OS
- prevent empty compiler variables that caused CMake configuration errors on Ubuntu

------
https://chatgpt.com/codex/tasks/task_e_68bb159cd8308327bd872862bbdeff1e