### PR TITLE
Fix CodeQL SARIF upload for MSVC analysis

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -53,12 +53,16 @@ jobs:
           cmakeBuildDirectory: ${{ env.build }}
           # Ruleset file that will determine what checks will be run
           ruleset: NativeRecommendedRules.ruleset
+          # Consolidate all diagnostics into a single SARIF log
+          sarifLogFile: msvc-analysis.sarif
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.run-analysis.outputs.sarif }}
+          # Ensure the SARIF upload has a unique category
+          category: msvc-code-analysis
 
       # Upload SARIF file as an Artifact to download and view
       # - name: Upload SARIF as an Artifact


### PR DESCRIPTION
## Summary
- Consolidate MSVC code analysis output into a single SARIF file
- Upload MSVC SARIF with a unique category to satisfy CodeQL action

------
https://chatgpt.com/codex/tasks/task_e_68bb1efb906883278edeb718e528b3e6