### PR TITLE
Fix CMake workflow and test paths

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -86,8 +86,11 @@ jobs:
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -S ${{ github.workspace }}
 
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+
     - name: Run Tests
       working-directory: ${{ steps.strings.outputs.build-output-dir }}
       # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }}
+      run: ctest --output-on-failure --build-config ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(Toybox LANGUAGES CXX)
+project(Toybox LANGUAGES C CXX)
 
 # Set global C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/Engine/Tests/CMakeLists.txt
+++ b/Engine/Tests/CMakeLists.txt
@@ -25,4 +25,4 @@ target_link_libraries(Tests PRIVATE
 )
 
 # Add tests
-add_test(NAME EngineTests COMMAND Tests)
+add_test(NAME EngineTests COMMAND $<TARGET_FILE:Tests>)


### PR DESCRIPTION
## Summary
- enable C language in project to satisfy C libraries
- use target file for test executable so ctest can find it
- build before running ctest in CI and show test output on failure

------
https://chatgpt.com/codex/tasks/task_e_68bb28353d288327b9f9c46d488859d2