### PR TITLE
Update MSVC code analysis workflow to avoid SARIF category conflict

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -46,23 +46,19 @@ jobs:
         run: cmake --build ${{ env.build }}
 
       - name: Initialize MSVC Code Analysis
-        uses: microsoft/msvc-code-analysis-action@04825f6d9e00f87422d6bf04e1a38b1f3ed60d99
-        # Provide a unique ID to access the sarif output path
+        uses: microsoft/msvc-code-analysis-action@v1
+        # Provide a unique ID to access the SARIF output path
         id: run-analysis
         with:
           cmakeBuildDirectory: ${{ env.build }}
           # Ruleset file that will determine what checks will be run
           ruleset: NativeRecommendedRules.ruleset
-          # Consolidate all diagnostics into a single SARIF log
-          sarifLogFile: msvc-analysis.sarif
 
       # Upload SARIF file to GitHub Code Scanning Alerts
       - name: Upload SARIF to GitHub
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ steps.run-analysis.outputs.sarif }}
-          # Ensure the SARIF upload has a unique category
-          category: msvc-code-analysis
 
       # Upload SARIF file as an Artifact to download and view
       # - name: Upload SARIF as an Artifact


### PR DESCRIPTION
## Summary
- use `microsoft/msvc-code-analysis-action@v1`
- drop explicit category to avoid multiple SARIF runs with the same category

## Testing
- `pip install yamllint` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bc6a22d8788327a5aa3524031b4d43