### PR TITLE
Fix GCC build issues

### DIFF
--- a/Engine/Tests/Math/BoundsTests.cpp
+++ b/Engine/Tests/Math/BoundsTests.cpp
@@ -1,4 +1,5 @@
 ﻿#include "PCH.h"
+#include <cmath>
 #include "Tbx/Math/Bounds.h"
 #include "Tbx/Math/Trig.h"
 #include "Tbx/Math/Constants.h"


### PR DESCRIPTION
## Summary
- cast plugin load/unload symbols using reinterpret_cast instead of static_cast
- include cmath in bounds tests to use std::tan

## Testing
- `cmake -S . -B build` *(fails: source directories under Dependencies and Plugins missing CMakeLists.txt files)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbc8f76308327ad7b01f20b09eeb4