### PR TITLE
Refactor EventCoordinator to use function keys

### DIFF
--- a/Engine/Include/Tbx/App/App.h
+++ b/Engine/Include/Tbx/App/App.h
@@ -80,8 +80,5 @@ namespace Tbx
         WindowStack _windowStack = {};
 
         Uid _mainWindowId = Invalid::Uid;
-
-        Uid _windowOpenedEventId = Invalid::Uid;
-        Uid _windowClosedEventId = Invalid::Uid;
     };
 }

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -39,10 +39,7 @@ namespace Tbx
         static void OnWindowResized(const WindowResizedEvent& e);
         static void OnBoxOpened(const OpenedBoxEvent& e);
 
-        static Uid _windowCreatedEventId;
-        static Uid _windowClosedEventId;
-        static Uid _windowResizedEventId;
-        static Uid _boxOpenedEventId;
+        // Event subscriptions are tracked by function signatures so we no longer need UIDs.
 
         static std::map<Uid, std::shared_ptr<IRenderer>> _renderers;
         static std::weak_ptr<IRendererFactoryPlugin> _renderFactory;

--- a/Engine/Source/Tbx/App/App.cpp
+++ b/Engine/Source/Tbx/App/App.cpp
@@ -53,7 +53,7 @@ namespace Tbx
         _instance = this;
         _status = AppStatus::Initializing;
 
-        _windowClosedEventId = EventCoordinator::Subscribe<WindowClosedEvent>(TBX_BIND_FN(OnWindowClosed));
+        EventCoordinator::Subscribe<WindowClosedEvent>(this, &App::OnWindowClosed);
 
         // Add default layers (order is important as they will be updated and destroyed in reverse order)
         EmplaceLayer<EventCoordinatorLayer>();
@@ -136,7 +136,7 @@ namespace Tbx
         OnShutdown();
 
         // Unsub to window events and shutdown events
-        EventCoordinator::Unsubscribe<WindowClosedEvent>(_windowClosedEventId);
+        EventCoordinator::Unsubscribe<WindowClosedEvent>(this, &App::OnWindowClosed);
 
         // Clear windows
         _windowStack.Clear();

--- a/Engine/Source/Tbx/Events/EventCoordinator.cpp
+++ b/Engine/Source/Tbx/Events/EventCoordinator.cpp
@@ -34,7 +34,7 @@ namespace Tbx
 
     //////////// Event Coordinator ///////////////
 
-    std::unordered_map<hash, std::vector<Callback<Event>>> EventCoordinator::_subscribers = {};
+    std::unordered_map<std::size_t, std::unordered_map<std::size_t, EventCallback>> EventCoordinator::_subscribers = {};
     std::mutex EventCoordinator::_subscribersMutex;
 
     void EventCoordinator::ClearSubscribers()
@@ -43,7 +43,7 @@ namespace Tbx
         _subscribers.clear();
     }
 
-    std::unordered_map<hash, std::vector<Callback<Event>>>& EventCoordinator::GetSubscribers()
+    std::unordered_map<std::size_t, std::unordered_map<std::size_t, EventCallback>>& EventCoordinator::GetSubscribers()
     {
         return _subscribers;
     }

--- a/Engine/Source/Tbx/Graphics/Rendering.cpp
+++ b/Engine/Source/Tbx/Graphics/Rendering.cpp
@@ -12,27 +12,22 @@ namespace Tbx
 {
     std::weak_ptr<IRendererFactoryPlugin> Rendering::_renderFactory = {};
     std::map<Uid, std::shared_ptr<IRenderer>> Rendering::_renderers = {};
-    Uid Rendering::_windowCreatedEventId = Invalid::Uid;
-    Uid Rendering::_windowClosedEventId = Invalid::Uid;
-    Uid Rendering::_windowResizedEventId = Invalid::Uid;
-    Uid Rendering::_boxOpenedEventId = Invalid::Uid;
-
     void Rendering::Initialize()
     {
-        _windowCreatedEventId = EventCoordinator::Subscribe<WindowOpenedEvent>(TBX_BIND_STATIC_FN(Rendering::OnWindowOpened));
-        _windowClosedEventId = EventCoordinator::Subscribe<WindowClosedEvent>(TBX_BIND_STATIC_FN(Rendering::OnWindowClosed));
-        _windowResizedEventId = EventCoordinator::Subscribe<WindowResizedEvent>(TBX_BIND_STATIC_FN(Rendering::OnWindowResized));
-        _boxOpenedEventId = EventCoordinator::Subscribe<OpenedBoxEvent>(TBX_BIND_STATIC_FN(Rendering::OnBoxOpened));
+        EventCoordinator::Subscribe<WindowOpenedEvent>(&Rendering::OnWindowOpened);
+        EventCoordinator::Subscribe<WindowClosedEvent>(&Rendering::OnWindowClosed);
+        EventCoordinator::Subscribe<WindowResizedEvent>(&Rendering::OnWindowResized);
+        EventCoordinator::Subscribe<OpenedBoxEvent>(&Rendering::OnBoxOpened);
 
         _renderFactory = PluginServer::Get<IRendererFactoryPlugin>();
     }
 
     void Rendering::Shutdown()
     {
-        EventCoordinator::Unsubscribe<WindowOpenedEvent>(_windowCreatedEventId);
-        EventCoordinator::Unsubscribe<WindowClosedEvent>(_windowClosedEventId);
-        EventCoordinator::Unsubscribe<WindowClosedEvent>(_windowResizedEventId);
-        EventCoordinator::Unsubscribe<WindowClosedEvent>(_boxOpenedEventId);
+        EventCoordinator::Unsubscribe<WindowOpenedEvent>(&Rendering::OnWindowOpened);
+        EventCoordinator::Unsubscribe<WindowClosedEvent>(&Rendering::OnWindowClosed);
+        EventCoordinator::Unsubscribe<WindowResizedEvent>(&Rendering::OnWindowResized);
+        EventCoordinator::Unsubscribe<OpenedBoxEvent>(&Rendering::OnBoxOpened);
     }
 
     void Rendering::DrawFrame()


### PR DESCRIPTION
## Summary
- Use function signature hashes as subscription keys
- Remove callback UID tracking across App and Rendering
- Streamline subscribe/unsubscribe API to accept function pointers

## Testing
- `g++ -std=c++20 -IEngine/Include -c Engine/Source/Tbx/Events/EventCoordinator.cpp -o /tmp/EventCoordinator.o && ls -l /tmp/EventCoordinator.o`
- `cmake -S . -B build` *(fails: Dependencies/... does not contain a CMakeLists.txt file)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8a629950832798df698fb73a84e4