### PR TITLE
fix: update labeler config for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,22 +1,32 @@
 source:
-  - 'Engine/**'
+  - changed-files:
+      - any-glob-to-any-file: 'Engine/**'
 examples:
-  - 'Examples/**'
+  - changed-files:
+      - any-glob-to-any-file: 'Examples/**'
 launcher:
-  - 'Launcher/**'
+  - changed-files:
+      - any-glob-to-any-file: 'Launcher/**'
 plugins:
-  - 'Plugins/**'
+  - changed-files:
+      - any-glob-to-any-file: 'Plugins/**'
 dependencies:
-  - 'Dependencies/**'
+  - changed-files:
+      - any-glob-to-any-file: 'Dependencies/**'
 build system:
-  - '**/CMakeLists.txt'
-  - '**/CMakePresets.json'
-  - '**/*.cmake'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/CMakeLists.txt'
+          - '**/CMakePresets.json'
+          - '**/*.cmake'
 automation:
-  - '.github/workflows/**'
-  - '.github/labeler.yml'
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/labeler.yml'
 documentation:
-  - '**/*.md'
+  - changed-files:
+      - any-glob-to-any-file: '**/*.md'
 feature:
   - head-branch: ['feature']
 patch:


### PR DESCRIPTION
## Summary
- fix labeler error by using `changed-files` syntax required by `actions/labeler@v5`

## Testing
- `python - <<'PY'` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb570b94832787fa4211631d8496