### PR TITLE
Finalize runtime and windowing layer responsibilities

### DIFF
--- a/Engine/Include/Tbx/App/App.h
+++ b/Engine/Include/Tbx/App/App.h
@@ -8,6 +8,7 @@
 #include "Tbx/Layers/LayerManager.h"
 #include "Tbx/Plugins/PluginServer.h"
 #include <memory>
+#include <vector>
 
 namespace Tbx
 {
@@ -43,6 +44,10 @@ namespace Tbx
         EXPORT std::shared_ptr<PluginServer> GetPluginServer();
         EXPORT std::shared_ptr<AssetServer> GetAssetServer();
 
+        EXPORT void AddRuntime(const std::shared_ptr<IRuntime>& runtime);
+        EXPORT void RemoveRuntime(const std::shared_ptr<IRuntime>& runtime);
+        EXPORT std::vector<std::shared_ptr<IRuntime>> GetRuntimes() const;
+
     protected:
         EXPORT virtual void OnLaunch() {};
         EXPORT virtual void OnUpdate() {};
@@ -63,8 +68,5 @@ namespace Tbx
         std::shared_ptr<PluginServer> _pluginServer = nullptr;
         std::shared_ptr<AssetServer> _assetServer = nullptr;
 
-        // TODO: Both of these should go into their own layers
-        std::shared_ptr<WindowManager> _windowManager = nullptr;
-        std::vector<std::shared_ptr<IRuntime>> _runtimes = {};
     };
 }

--- a/Engine/Include/Tbx/App/IRuntime.h
+++ b/Engine/Include/Tbx/App/IRuntime.h
@@ -1,8 +1,18 @@
 #pragma once
+#include "Tbx/DllExport.h"
+#include <memory>
 
 namespace Tbx
 {
-	class IRuntime
-	{
-	};
+    class App;
+
+    class EXPORT IRuntime
+    {
+    public:
+        virtual ~IRuntime() = default;
+
+        virtual void OnAttach(std::weak_ptr<App> app) {}
+        virtual void OnDetach(std::weak_ptr<App> app) {}
+        virtual void OnUpdate(std::weak_ptr<App> app) {}
+    };
 }

--- a/Engine/Source/Tbx/Layers/RuntimeLayer.cpp
+++ b/Engine/Source/Tbx/Layers/RuntimeLayer.cpp
@@ -1,0 +1,119 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Layers/RuntimeLayer.h"
+#include "Tbx/App/App.h"
+
+namespace Tbx
+{
+    RuntimeLayer::RuntimeLayer(std::weak_ptr<App> app)
+        : Layer("Runtime"), _app(std::move(app))
+    {
+    }
+
+    void RuntimeLayer::OnAttach()
+    {
+        _isAttached = true;
+        if (_app.expired())
+        {
+            return;
+        }
+
+        for (const auto& runtime : _runtimes)
+        {
+            AttachRuntime(runtime);
+        }
+    }
+
+    void RuntimeLayer::OnDetach()
+    {
+        for (const auto& runtime : std::ranges::reverse_view(_runtimes))
+        {
+            DetachRuntime(runtime);
+        }
+        _isAttached = false;
+    }
+
+    void RuntimeLayer::OnUpdate()
+    {
+        if (!_isAttached)
+        {
+            return;
+        }
+
+        if (_app.expired())
+        {
+            return;
+        }
+
+        for (const auto& runtime : _runtimes)
+        {
+            runtime->OnUpdate(_app);
+        }
+    }
+
+    void RuntimeLayer::AddRuntime(const std::shared_ptr<IRuntime>& runtime)
+    {
+        if (!runtime)
+        {
+            return;
+        }
+
+        if (std::find(_runtimes.begin(), _runtimes.end(), runtime) != _runtimes.end())
+        {
+            return;
+        }
+
+        _runtimes.push_back(runtime);
+
+        if (_isAttached)
+        {
+            AttachRuntime(runtime);
+        }
+    }
+
+    void RuntimeLayer::RemoveRuntime(const std::shared_ptr<IRuntime>& runtime)
+    {
+        if (!runtime)
+        {
+            return;
+        }
+
+        auto it = std::find(_runtimes.begin(), _runtimes.end(), runtime);
+        if (it == _runtimes.end())
+        {
+            return;
+        }
+
+        if (_isAttached)
+        {
+            DetachRuntime(runtime);
+        }
+
+        _runtimes.erase(it);
+    }
+
+    std::vector<std::shared_ptr<IRuntime>> RuntimeLayer::GetRuntimes() const
+    {
+        return _runtimes;
+    }
+
+    void RuntimeLayer::AttachRuntime(const std::shared_ptr<IRuntime>& runtime)
+    {
+        if (!runtime || _app.expired())
+        {
+            return;
+        }
+
+        runtime->OnAttach(_app);
+    }
+
+    void RuntimeLayer::DetachRuntime(const std::shared_ptr<IRuntime>& runtime)
+    {
+        if (!runtime)
+        {
+            return;
+        }
+
+        runtime->OnDetach(_app);
+    }
+}
+

--- a/Engine/Source/Tbx/Layers/RuntimeLayer.h
+++ b/Engine/Source/Tbx/Layers/RuntimeLayer.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Tbx/Layers/Layer.h"
+#include "Tbx/App/IRuntime.h"
+#include <memory>
+#include <vector>
+
+namespace Tbx
+{
+    class App;
+
+    class RuntimeLayer : public Layer
+    {
+    public:
+        explicit RuntimeLayer(std::weak_ptr<App> app);
+
+        void OnAttach() override;
+        void OnDetach() override;
+        void OnUpdate() override;
+
+        void AddRuntime(const std::shared_ptr<IRuntime>& runtime);
+        void RemoveRuntime(const std::shared_ptr<IRuntime>& runtime);
+        std::vector<std::shared_ptr<IRuntime>> GetRuntimes() const;
+
+    private:
+        void AttachRuntime(const std::shared_ptr<IRuntime>& runtime);
+        void DetachRuntime(const std::shared_ptr<IRuntime>& runtime);
+
+        std::weak_ptr<App> _app;
+        std::vector<std::shared_ptr<IRuntime>> _runtimes;
+        bool _isAttached = false;
+    };
+}
+

--- a/Engine/Source/Tbx/Layers/WindowingLayer.cpp
+++ b/Engine/Source/Tbx/Layers/WindowingLayer.cpp
@@ -1,0 +1,51 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Layers/WindowingLayer.h"
+
+namespace Tbx
+{
+    WindowingLayer::WindowingLayer(std::shared_ptr<IWindowFactory> windowFactory,
+                                   std::shared_ptr<EventBus> eventBus,
+                                   std::string mainWindowTitle,
+                                   WindowMode mainWindowMode,
+                                   Size mainWindowSize)
+        : Layer("Windowing"),
+          _mainWindowTitle(std::move(mainWindowTitle)),
+          _mainWindowMode(mainWindowMode),
+          _mainWindowSize(mainWindowSize)
+    {
+        _windowManager = std::make_shared<WindowManager>(windowFactory, eventBus);
+        _shouldCreateMainWindow = !_mainWindowTitle.empty();
+    }
+
+    void WindowingLayer::OnAttach()
+    {
+        if (_windowManager && _shouldCreateMainWindow)
+        {
+            _windowManager->OpenWindow(_mainWindowTitle, _mainWindowMode, _mainWindowSize);
+            _shouldCreateMainWindow = false;
+        }
+    }
+
+    void WindowingLayer::OnDetach()
+    {
+        if (_windowManager)
+        {
+            _windowManager->CloseAllWindows();
+        }
+        _shouldCreateMainWindow = !_mainWindowTitle.empty();
+    }
+
+    void WindowingLayer::OnUpdate()
+    {
+        if (_windowManager)
+        {
+            _windowManager->UpdateWindows();
+        }
+    }
+
+    std::shared_ptr<WindowManager> WindowingLayer::GetWindowManager() const
+    {
+        return _windowManager;
+    }
+}
+

--- a/Engine/Source/Tbx/Layers/WindowingLayer.h
+++ b/Engine/Source/Tbx/Layers/WindowingLayer.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Tbx/Layers/Layer.h"
+#include "Tbx/Math/Size.h"
+#include "Tbx/Windowing/WindowManager.h"
+#include <memory>
+#include <string>
+
+namespace Tbx
+{
+    class WindowingLayer : public Layer
+    {
+    public:
+        WindowingLayer(std::shared_ptr<IWindowFactory> windowFactory,
+                       std::shared_ptr<EventBus> eventBus,
+                       std::string mainWindowTitle,
+                       WindowMode mainWindowMode,
+                       Size mainWindowSize);
+
+        void OnAttach() override;
+        void OnDetach() override;
+        void OnUpdate() override;
+
+        std::shared_ptr<WindowManager> GetWindowManager() const;
+
+    private:
+        std::shared_ptr<WindowManager> _windowManager;
+        std::string _mainWindowTitle;
+        WindowMode _mainWindowMode;
+        Size _mainWindowSize;
+        bool _shouldCreateMainWindow = false;
+    };
+}
+


### PR DESCRIPTION
## Summary
- construct the windowing layer with the main window configuration and let its attach hook open the primary window
- register the windowing layer alongside the other core layers before the runtime layer and inline runtime-layer lookups on the app
- keep the windowing layer ready to recreate the main window after detaches by tracking its pending state

------
https://chatgpt.com/codex/tasks/task_e_68cb638d33048327976c81f761f0694a