### PR TITLE
Clarify app layer management and rendering flush flow

### DIFF
--- a/Engine/Include/Tbx/App/App.h
+++ b/Engine/Include/Tbx/App/App.h
@@ -4,10 +4,15 @@
 #include "Tbx/Assets/AssetServer.h"
 #include "Tbx/Events/EventBus.h"
 #include "Tbx/Events/WindowEvents.h"
-#include "Tbx/Windowing/WindowManager.h"
+#include "Tbx/Layers/Layer.h"
 #include "Tbx/Layers/LayerManager.h"
 #include "Tbx/Plugins/PluginServer.h"
 #include "Tbx/Memory/Refs.h"
+#include "Tbx/Math/Int.h"
+#include "Tbx/Math/Size.h"
+#include "Tbx/Ids/Uid.h"
+#include "Tbx/Windowing/IWindow.h"
+#include "Tbx/Windowing/WindowManager.h"
 #include <memory>
 #include <vector>
 
@@ -33,33 +38,132 @@ namespace Tbx
     class EXPORT App : std::enable_shared_from_this<App>
     {
     public:
+        /// <summary>
+        /// Creates a new application with the provided display name.
+        /// </summary>
         explicit(false) App(const std::string_view& name);
+
+        /// <summary>
+        /// Ensures resources created by the application are properly released.
+        /// </summary>
         virtual ~App();
 
+        /// <summary>
+        /// Starts the application run loop and executes until shutdown is requested.
+        /// </summary>
         void Run();
+
+        /// <summary>
+        /// Requests that the application terminate after the current frame.
+        /// </summary>
         void Close();
 
+        /// <summary>
+        /// Applies the provided settings to the running application instance.
+        /// </summary>
         void SetSettings(const Settings& settings);
+
+        /// <summary>
+        /// Retrieves the current application settings.
+        /// </summary>
         const Settings& GetSettings() const;
 
+        /// <summary>
+        /// Returns the status associated with the application's lifecycle.
+        /// </summary>
         const AppStatus& GetStatus() const;
+
+        /// <summary>
+        /// Provides the name used to identify the application instance.
+        /// </summary>
         const std::string& GetName() const;
 
+        /// <summary>
+        /// Exposes the event bus used to publish and subscribe to engine events.
+        /// </summary>
         Tbx::Ref<EventBus> GetEventBus();
 
-        // TODO: hide behind some methods AddLayer<LayerType>(args...), RemoveLayer(name), GetLayer(name), GetLayers<Type>(), etc...
-        // TODO: ensure each layer has a unique name.
-        Tbx::Ref<LayerManager> GetLayerManager();
+        /// <summary>
+        /// Returns the plugin server powering extensible engine systems.
+        /// </summary>
+        Tbx::Ref<PluginServer> GetPluginServer();
+
+        /// <summary>
+        /// Provides access to the asset server responsible for content streaming.
+        /// </summary>
+        Tbx::Ref<AssetServer> GetAssetServer();
+
+        /// <summary>
+        /// Registers a new layer with the application-managed layer manager.
+        /// </summary>
+        void AddLayer(const Tbx::Ref<Layer>& layer);
+
+        /// <summary>
+        /// Removes a layer by name from the layer manager.
+        /// </summary>
+        void RemoveLayer(const std::string& name);
+
+        /// <summary>
+        /// Removes a specific layer instance from the layer manager.
+        /// </summary>
+        void RemoveLayer(const Tbx::Ref<Layer>& layer);
+
+        /// <summary>
+        /// Retrieves a layer by name from the layer manager.
+        /// </summary>
+        Tbx::Ref<Layer> GetLayer(const std::string& name) const;
+
+        /// <summary>
+        /// Returns the set of layers currently managed by the application.
+        /// </summary>
+        std::vector<Tbx::Ref<Layer>> GetLayers() const;
 
         // TODO: Get rid of window manager and make the app fully own windows.
         // They should be behind some methods like layer: OpenNewWindow(name, mode, size=default), GetWindow(id or name), etc..
-        Tbx::Ref<WindowManager> GetWindowManager();
 
-        Tbx::Ref<PluginServer> GetPluginServer();
-        Tbx::Ref<AssetServer> GetAssetServer();
+        /// <summary>
+        /// Opens a new window with the provided description and returns its unique identifier.
+        /// </summary>
+        Uid OpenWindow(const std::string& name, const WindowMode& mode, const Size& size = Size(1920, 1080));
 
+        /// <summary>
+        /// Closes the window associated with the supplied identifier.
+        /// </summary>
+        void CloseWindow(const Uid& id);
+
+        /// <summary>
+        /// Closes all open windows owned by the application.
+        /// </summary>
+        void CloseAllWindows();
+
+        /// <summary>
+        /// Returns a collection of currently open windows.
+        /// </summary>
+        std::vector<Tbx::Ref<IWindow>> GetOpenWindows() const;
+
+        /// <summary>
+        /// Retrieves a specific window by its identifier.
+        /// </summary>
+        Tbx::Ref<IWindow> GetWindow(const Uid& id) const;
+
+        /// <summary>
+        /// Returns the main window used by the application.
+        /// </summary>
+        Tbx::Ref<IWindow> GetMainWindow() const;
+
+        /// <summary>
+        /// Registers a runtime with the application so it participates in updates.
+        /// </summary>
         void AddRuntime(const Tbx::Ref<IRuntime>& runtime);
+
+        /// <summary>
+        /// Removes a runtime from the application.
+        /// </summary>
         void RemoveRuntime(const Tbx::Ref<IRuntime>& runtime);
+
+        /// <summary>
+        /// Provides the runtimes currently registered with the application.
+        /// </summary>
         std::vector<Tbx::Ref<IRuntime>> GetRuntimes() const;
 
     protected:
@@ -72,6 +176,8 @@ namespace Tbx
         void Update();
         void Shutdown();
         void OnWindowClosed(const WindowClosedEvent& e);
+
+        Tbx::Ref<WindowManager> GetWindowManager() const;
 
     private:
         std::string _name = "App";

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -1,0 +1,73 @@
+#pragma once
+#include "Tbx/DllExport.h"
+#include "Tbx/Graphics/IRenderer.h"
+#include "Tbx/Graphics/Buffers.h"
+#include "Tbx/Windowing/IWindow.h"
+#include "Tbx/TSS/Stage.h"
+#include "Tbx/Events/AppEvents.h"
+#include "Tbx/Events/EventBus.h"
+#include "Tbx/Events/RenderEvents.h"
+#include "Tbx/Events/TSSEvents.h"
+#include "Tbx/Events/WindowEvents.h"
+#include "Tbx/Memory/Refs.h"
+#include "Tbx/Graphics/Color.h"
+#include <vector>
+
+namespace Tbx
+{
+    /// <summary>
+    /// Coordinates render targets, windows, and stage composition for a frame.
+    /// </summary>
+    class Rendering
+    {
+    public:
+        EXPORT Rendering(Tbx::Ref<IRendererFactory> rendererFactory, Tbx::Ref<EventBus> eventBus);
+        EXPORT ~Rendering();
+
+        /// <summary>
+        /// Drives the rendering pipeline for all open stages and windows.
+        /// </summary>
+        EXPORT void Update();
+
+        /// <summary>
+        /// Retrieves the renderer associated with the provided window.
+        /// </summary>
+        EXPORT Tbx::Ref<IRenderer> GetRenderer(const Tbx::Ref<IWindow>& window) const;
+
+    private:
+        void DrawFrame();
+
+        /// <summary>
+        /// Marks the provided stage for GPU resource upload on the next frame.
+        /// </summary>
+        void QueueStageUpload(const Tbx::Ref<Stage>& stage);
+
+        /// <summary>
+        /// Uploads any pending stage resources to all active renderers.
+        /// </summary>
+        void FlushPendingUploads();
+
+        /// <summary>
+        /// Submits the provided render buffer to all active renderers and presents the results.
+        /// </summary>
+        void FlushRenderBuffer(const FrameBuffer& renderBuffer);
+        void AddStage(const Tbx::Ref<Stage>& stage);
+        void RemoveStage(const Tbx::Ref<Stage>& stage);
+
+        void OnWindowOpened(const WindowOpenedEvent& e);
+        void OnWindowClosed(const WindowClosedEvent& e);
+        void OnAppSettingsChanged(const AppSettingsChangedEvent& e);
+        void OnStageOpened(const StageOpenedEvent& e);
+        void OnStageClosed(const StageClosedEvent& e);
+
+    private:
+        std::vector<Tbx::Ref<Stage>> _openStages = {};
+        std::vector<Tbx::Ref<IWindow>> _windows = {};
+        std::vector<Tbx::Ref<IRenderer>> _renderers = {};
+        std::vector<Tbx::Ref<Stage>> _pendingUploadStages = {};
+        Tbx::Ref<IRendererFactory> _rendererFactory = {};
+        Tbx::Ref<EventBus> _eventBus = {};
+        Tbx::RgbaColor _clearColor = {};
+    };
+}
+

--- a/Engine/Include/Tbx/Layers/LayerManager.h
+++ b/Engine/Include/Tbx/Layers/LayerManager.h
@@ -25,6 +25,7 @@ namespace Tbx
 
         EXPORT Tbx::Ref<Layer> GetLayer(Tbx::uint index) const;
         EXPORT Tbx::Ref<Layer> GetLayer(const std::string& name) const;
+        EXPORT std::vector<Tbx::Ref<Layer>> GetLayers() const;
 
         template <typename T>
         EXPORT Tbx::Ref<T> GetLayer() const

--- a/Engine/Include/Tbx/Layers/LayerStack.h
+++ b/Engine/Include/Tbx/Layers/LayerStack.h
@@ -40,7 +40,7 @@ namespace Tbx
         /// Returns the number of layers currently registered in the stack.
         /// </summary>
         EXPORT Tbx::uint GetCount() const { return static_cast<Tbx::uint>(_layers.size()); }
-      
+
         EXPORT std::vector<Tbx::Ref<Layer>>::iterator begin() { return _layers.begin(); }
         EXPORT std::vector<Tbx::Ref<Layer>>::iterator end() { return _layers.end(); }
         EXPORT std::vector<Tbx::Ref<Layer>>::const_iterator begin() const { return _layers.begin(); }

--- a/Engine/Include/Tbx/Layers/RenderingLayer.h
+++ b/Engine/Include/Tbx/Layers/RenderingLayer.h
@@ -1,27 +1,21 @@
 #pragma once
 #include "Tbx/DllExport.h"
-#include "Tbx/TSS/Stage.h"
 #include "Tbx/Layers/Layer.h"
 #include "Tbx/Graphics/IRenderer.h"
+#include "Tbx/Graphics/Rendering.h"
 #include "Tbx/Windowing/IWindow.h"
 #include "Tbx/Events/EventBus.h"
-#include "Tbx/Events/WindowEvents.h"
-#include "Tbx/Events/AppEvents.h"
 #include "Tbx/Memory/Refs.h"
-#include <vector>
 
 namespace Tbx
 {
     /// <summary>
-    /// The apps rendering layer.
-    /// Deals with rendering all the items in the apps 3d space.
+    /// The application's rendering layer that connects the high-level layer system to the rendering subsystem.
     /// </summary>
     class RenderingLayer : public Layer
     {
     public:
-        EXPORT RenderingLayer(
-            Tbx::Ref<IRendererFactory> renderFactory,
-            Tbx::Ref<EventBus> eventBus);
+        EXPORT RenderingLayer(Tbx::Ref<IRendererFactory> renderFactory, Tbx::Ref<EventBus> eventBus);
 
         /// <summary>
         /// Gets the renderer used by a given window.
@@ -32,19 +26,7 @@ namespace Tbx
         void OnUpdate() override;
 
     private:
-        void DrawFrame();
-        void OnWindowOpened(const WindowOpenedEvent& e);
-        void OnWindowClosed(const WindowClosedEvent& e);
-        void OnAppSettingsChanged(const AppSettingsChangedEvent& e);
-
-    private:
-        // TODO: listen for the open/close stage event and add/remove open stages here
-        std::vector<Tbx::Ref<Stage>> _openStages = {};
-        std::vector<Tbx::Ref<IWindow>> _windows = {};
-        std::vector<Tbx::Ref<IRenderer>> _renderers = {};
-        Tbx::Ref<IRendererFactory> _renderFactory = {};
-        Tbx::Ref<EventBus> _eventBus = {};
-        Tbx::RgbaColor _clearColor = {};
-        bool _firstFrame = true;
+        Tbx::ExclusiveRef<Rendering> _rendering = nullptr;
     };
 }
+

--- a/Engine/Source/Tbx/App/App.cpp
+++ b/Engine/Source/Tbx/App/App.cpp
@@ -76,11 +76,11 @@ namespace Tbx
         auto log = std::make_shared<LogLayer>(_pluginServer->GetPlugin<ILoggerFactory>());
         auto windowingLayer = std::make_shared<WindowingLayer>(_name, _pluginServer->GetPlugin<IWindowFactory>(), _eventBus);
         auto runtime = std::make_shared<RuntimeLayer>(self);
-        _layerManager->AddLayer(log);
-        _layerManager->AddLayer(input);
-        _layerManager->AddLayer(windowingLayer);
-        _layerManager->AddLayer(runtime);
-        _layerManager->AddLayer(rendering);
+        AddLayer(log);
+        AddLayer(input);
+        AddLayer(windowingLayer);
+        AddLayer(runtime);
+        AddLayer(rendering);
 
         _eventBus->Subscribe(this, &App::OnWindowClosed);
 
@@ -116,6 +116,7 @@ namespace Tbx
 
         OnUpdate();
 
+        TBX_ASSERT(_layerManager, "Layer manager must exist before updating layers.");
         _layerManager->UpdateLayers();
 
         if (_status != AppStatus::Running) return;
@@ -145,14 +146,8 @@ namespace Tbx
     void App::OnWindowClosed(const WindowClosedEvent& e)
     {
         // If the window is our main window, set running flag to false which will trigger the app to close
-        auto window = e.GetWindow();
-        const auto windowManager = GetWindowManager();
-        if (!windowManager)
-        {
-            return;
-        }
-
-        auto mainWindow = windowManager->GetMainWindow();
+        const auto window = e.GetWindow();
+        const auto mainWindow = GetMainWindow();
         if (window && mainWindow && window->GetId() == mainWindow->GetId())
         {
             // Stop running and close all windows
@@ -175,20 +170,34 @@ namespace Tbx
         return _eventBus;
     }
 
-    Tbx::Ref<LayerManager> App::GetLayerManager()
+    void App::AddLayer(const Tbx::Ref<Layer>& layer)
     {
-        return _layerManager;
+        TBX_ASSERT(_layerManager, "Layer manager must exist before adding layers.");
+        _layerManager->AddLayer(layer);
     }
 
-    Tbx::Ref<WindowManager> App::GetWindowManager()
+    void App::RemoveLayer(const std::string& name)
     {
-        if (!_layerManager)
-        {
-            return nullptr;
-        }
+        TBX_ASSERT(_layerManager, "Layer manager must exist before removing layers.");
+        _layerManager->RemoveLayer(name);
+    }
 
-        const auto windowingLayer = _layerManager->GetLayer<WindowingLayer>();
-        return windowingLayer ? windowingLayer->GetWindowManager() : nullptr;
+    void App::RemoveLayer(const Tbx::Ref<Layer>& layer)
+    {
+        TBX_ASSERT(_layerManager, "Layer manager must exist before removing layers.");
+        _layerManager->RemoveLayer(layer);
+    }
+
+    Tbx::Ref<Layer> App::GetLayer(const std::string& name) const
+    {
+        TBX_ASSERT(_layerManager, "Layer manager must exist before querying layers.");
+        return _layerManager->GetLayer(name);
+    }
+
+    std::vector<Tbx::Ref<Layer>> App::GetLayers() const
+    {
+        TBX_ASSERT(_layerManager, "Layer manager must exist before querying layers.");
+        return _layerManager->GetLayers();
     }
 
     Tbx::Ref<PluginServer> App::GetPluginServer()
@@ -222,7 +231,8 @@ namespace Tbx
             return;
         }
 
-        const auto runtimeLayer = _layerManager ? _layerManager->GetLayer<RuntimeLayer>() : nullptr;
+        TBX_ASSERT(_layerManager, "Layer manager must exist before adding runtimes.");
+        const auto runtimeLayer = _layerManager->GetLayer<RuntimeLayer>();
         TBX_ASSERT(runtimeLayer, "Runtime layer must exist before adding runtimes");
         runtimeLayer->AddRuntime(runtime);
     }
@@ -234,21 +244,64 @@ namespace Tbx
             return;
         }
 
-        const auto runtimeLayer = _layerManager ? _layerManager->GetLayer<RuntimeLayer>() : nullptr;
-        if (runtimeLayer)
-        {
-            runtimeLayer->RemoveRuntime(runtime);
-        }
+        TBX_ASSERT(_layerManager, "Layer manager must exist before removing runtimes.");
+        const auto runtimeLayer = _layerManager->GetLayer<RuntimeLayer>();
+        TBX_ASSERT(runtimeLayer, "Runtime layer must exist before removing runtimes.");
+        runtimeLayer->RemoveRuntime(runtime);
     }
 
     std::vector<Tbx::Ref<IRuntime>> App::GetRuntimes() const
     {
-        const auto runtimeLayer = _layerManager ? _layerManager->GetLayer<RuntimeLayer>() : nullptr;
-        if (runtimeLayer)
-        {
-            return runtimeLayer->GetRuntimes();
-        }
+        TBX_ASSERT(_layerManager, "Layer manager must exist before querying runtimes.");
+        const auto runtimeLayer = _layerManager->GetLayer<RuntimeLayer>();
+        TBX_ASSERT(runtimeLayer, "Runtime layer must exist before querying runtimes.");
+        return runtimeLayer->GetRuntimes();
+    }
 
-        return {};
+    Uid App::OpenWindow(const std::string& name, const WindowMode& mode, const Size& size)
+    {
+        auto windowManager = GetWindowManager();
+        return windowManager->OpenWindow(name, mode, size);
+    }
+
+    void App::CloseWindow(const Uid& id)
+    {
+        auto windowManager = GetWindowManager();
+        windowManager->CloseWindow(id);
+    }
+
+    void App::CloseAllWindows()
+    {
+        auto windowManager = GetWindowManager();
+        windowManager->CloseAllWindows();
+    }
+
+    std::vector<Tbx::Ref<IWindow>> App::GetOpenWindows() const
+    {
+        auto windowManager = GetWindowManager();
+        const auto& windows = windowManager->GetAllWindows();
+        return { windows.begin(), windows.end() };
+    }
+
+    Tbx::Ref<IWindow> App::GetWindow(const Uid& id) const
+    {
+        auto windowManager = GetWindowManager();
+        return windowManager->GetWindow(id);
+    }
+
+    Tbx::Ref<IWindow> App::GetMainWindow() const
+    {
+        auto windowManager = GetWindowManager();
+        return windowManager->GetMainWindow();
+    }
+
+    Tbx::Ref<WindowManager> App::GetWindowManager() const
+    {
+        TBX_ASSERT(_layerManager, "Layer manager must exist before querying window manager.");
+        auto windowingLayer = _layerManager->GetLayer<WindowingLayer>();
+        TBX_ASSERT(windowingLayer, "Windowing layer must be registered before accessing window manager.");
+        auto windowManager = windowingLayer->GetWindowManager();
+        TBX_ASSERT(windowManager, "Window manager must exist before it can be used.");
+        return windowManager;
     }
 }

--- a/Engine/Source/Tbx/Graphics/Rendering.cpp
+++ b/Engine/Source/Tbx/Graphics/Rendering.cpp
@@ -1,0 +1,272 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Graphics/Rendering.h"
+#include "Tbx/Graphics/FrameBufferBuilder.h"
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+
+namespace Tbx
+{
+    Rendering::Rendering(Tbx::Ref<IRendererFactory> rendererFactory, Tbx::Ref<EventBus> eventBus)
+        : _rendererFactory(rendererFactory)
+        , _eventBus(eventBus)
+    {
+        TBX_ASSERT(_rendererFactory, "Rendering requires a valid renderer factory instance.");
+        TBX_ASSERT(_eventBus, "Rendering requires a valid event bus instance.");
+
+        _eventBus->Subscribe(this, &Rendering::OnWindowOpened);
+        _eventBus->Subscribe(this, &Rendering::OnWindowClosed);
+        _eventBus->Subscribe(this, &Rendering::OnAppSettingsChanged);
+        _eventBus->Subscribe(this, &Rendering::OnStageOpened);
+        _eventBus->Subscribe(this, &Rendering::OnStageClosed);
+    }
+
+    Rendering::~Rendering()
+    {
+        _eventBus->Unsubscribe(this, &Rendering::OnWindowOpened);
+        _eventBus->Unsubscribe(this, &Rendering::OnWindowClosed);
+        _eventBus->Unsubscribe(this, &Rendering::OnAppSettingsChanged);
+        _eventBus->Unsubscribe(this, &Rendering::OnStageOpened);
+        _eventBus->Unsubscribe(this, &Rendering::OnStageClosed);
+    }
+
+    void Rendering::Update()
+    {
+        if (_renderers.empty() || _openStages.empty())
+        {
+            return;
+        }
+
+        DrawFrame();
+    }
+
+    Tbx::Ref<IRenderer> Rendering::GetRenderer(const Tbx::Ref<IWindow>& window) const
+    {
+        if (!window)
+        {
+            return nullptr;
+        }
+
+        auto it = std::find(_windows.begin(), _windows.end(), window);
+        if (it == _windows.end())
+        {
+            TBX_ASSERT(false, "No renderer found for window");
+            return nullptr;
+        }
+
+        const auto index = static_cast<size_t>(std::distance(_windows.begin(), it));
+        return index < _renderers.size() ? _renderers[index] : nullptr;
+    }
+
+    void Rendering::DrawFrame()
+    {
+        FlushPendingUploads();
+        FrameBuffer renderBuffer = {};
+
+        for (const auto& stage : _openStages)
+        {
+            if (!stage)
+            {
+                continue;
+            }
+
+            const auto spaceRoot = stage->GetRoot();
+            if (!spaceRoot)
+            {
+                continue;
+            }
+
+            FrameBufferBuilder builder;
+            const auto stageRenderBuffer = builder.BuildRenderBuffer(spaceRoot);
+            for (const auto& command : stageRenderBuffer)
+            {
+                renderBuffer.Add(command);
+            }
+        }
+
+        FlushRenderBuffer(renderBuffer);
+    }
+
+    void Rendering::QueueStageUpload(const Tbx::Ref<Stage>& stage)
+    {
+        if (!stage)
+        {
+            return;
+        }
+
+        const auto it = std::find(_pendingUploadStages.begin(), _pendingUploadStages.end(), stage);
+        if (it == _pendingUploadStages.end())
+        {
+            _pendingUploadStages.push_back(stage);
+        }
+    }
+
+    void Rendering::FlushPendingUploads()
+    {
+        if (_pendingUploadStages.empty())
+        {
+            return;
+        }
+
+        FrameBuffer uploadBuffer = {};
+        for (const auto& stage : _pendingUploadStages)
+        {
+            if (!stage)
+            {
+                continue;
+            }
+
+            const auto spaceRoot = stage->GetRoot();
+            if (!spaceRoot)
+            {
+                continue;
+            }
+
+            FrameBufferBuilder builder;
+            const auto stageUploadBuffer = builder.BuildUploadBuffer(spaceRoot);
+            for (const auto& command : stageUploadBuffer)
+            {
+                uploadBuffer.Add(command);
+            }
+        }
+
+        if (!uploadBuffer.GetCommands().empty())
+        {
+            for (const auto& renderer : _renderers)
+            {
+                if (!renderer)
+                {
+                    continue;
+                }
+
+                renderer->Flush();
+                renderer->Process(uploadBuffer);
+            }
+        }
+
+        _pendingUploadStages.clear();
+    }
+
+    void Rendering::FlushRenderBuffer(const FrameBuffer& renderBuffer)
+    {
+        for (size_t rendererIndex = 0; rendererIndex < _renderers.size(); ++rendererIndex)
+        {
+            const auto& renderer = _renderers[rendererIndex];
+            const auto& rendererWindow = _windows[rendererIndex];
+            if (!renderer || !rendererWindow)
+            {
+                continue;
+            }
+
+            renderer->SetViewport({ {0, 0}, rendererWindow->GetSize() });
+            renderer->Clear(_clearColor);
+            renderer->Process(renderBuffer);
+        }
+
+        if (_eventBus)
+        {
+            _eventBus->Send(RenderedFrameEvent());
+        }
+
+        for (const auto& window : _windows)
+        {
+            if (window)
+            {
+                window->SwapBuffers();
+            }
+        }
+    }
+
+    void Rendering::AddStage(const Tbx::Ref<Stage>& stage)
+    {
+        if (!stage)
+        {
+            return;
+        }
+
+        const auto it = std::find(_openStages.begin(), _openStages.end(), stage);
+        if (it != _openStages.end())
+        {
+            return;
+        }
+
+        _openStages.push_back(stage);
+        QueueStageUpload(stage);
+    }
+
+    void Rendering::RemoveStage(const Tbx::Ref<Stage>& stage)
+    {
+        if (!stage)
+        {
+            return;
+        }
+
+        auto it = std::find(_openStages.begin(), _openStages.end(), stage);
+        if (it != _openStages.end())
+        {
+            _openStages.erase(it);
+        }
+
+        auto pending = std::find(_pendingUploadStages.begin(), _pendingUploadStages.end(), stage);
+        if (pending != _pendingUploadStages.end())
+        {
+            _pendingUploadStages.erase(pending);
+        }
+    }
+
+    void Rendering::OnWindowOpened(const WindowOpenedEvent& e)
+    {
+        auto newWindow = e.GetWindow();
+        if (!newWindow)
+        {
+            return;
+        }
+
+        TBX_ASSERT(_rendererFactory, "Render factory plugin was unloaded! Cannot create new renderer");
+        if (!_rendererFactory)
+        {
+            return;
+        }
+
+        auto newRenderer = _rendererFactory->Create(newWindow);
+        _windows.push_back(newWindow);
+        _renderers.push_back(newRenderer);
+        for (const auto& stage : _openStages)
+        {
+            QueueStageUpload(stage);
+        }
+    }
+
+    void Rendering::OnWindowClosed(const WindowClosedEvent& e)
+    {
+        auto window = e.GetWindow();
+        auto it = std::find(_windows.begin(), _windows.end(), window);
+        if (it == _windows.end())
+        {
+            return;
+        }
+
+        const auto index = static_cast<size_t>(std::distance(_windows.begin(), it));
+        _windows.erase(_windows.begin() + static_cast<std::ptrdiff_t>(index));
+        if (index < _renderers.size())
+        {
+            _renderers.erase(_renderers.begin() + static_cast<std::ptrdiff_t>(index));
+        }
+    }
+
+    void Rendering::OnAppSettingsChanged(const AppSettingsChangedEvent& e)
+    {
+        _clearColor = e.GetNewSettings().ClearColor;
+    }
+
+    void Rendering::OnStageOpened(const StageOpenedEvent& e)
+    {
+        AddStage(e.GetStage());
+    }
+
+    void Rendering::OnStageClosed(const StageClosedEvent& e)
+    {
+        RemoveStage(e.GetStage());
+    }
+}
+

--- a/Engine/Source/Tbx/Ids/Guid.cpp
+++ b/Engine/Source/Tbx/Ids/Guid.cpp
@@ -1,13 +1,38 @@
 #include "Tbx/PCH.h"
 #include "Tbx/Ids/Guid.h"
 
+#include <random>
+
 namespace Tbx
 {
-	Guid Guid::Invalid = Guid("00000000-0000-0000-0000-000000000000");
+    Guid Guid::Invalid = Guid("00000000-0000-0000-0000-000000000000");
 
-	Guid Guid::Generate()
-	{
-		// TODO: implement
-		return Guid();
-	}
+    Guid Guid::Generate()
+    {
+        static thread_local std::mt19937_64 engine(std::random_device{}());
+        static constexpr char HexDigits[] = "0123456789abcdef";
+        std::uniform_int_distribution<int> distribution(0, 15);
+
+        std::string value(36, '\0');
+        value[8] = value[13] = value[18] = value[23] = '-';
+
+        for (std::size_t index = 0; index < value.size(); ++index)
+        {
+            if (value[index] == '-')
+            {
+                continue;
+            }
+
+            value[index] = HexDigits[distribution(engine)];
+        }
+
+        // Version field (UUID version 4)
+        value[14] = '4';
+
+        // Variant field (UUID variant 1)
+        int variant = distribution(engine) & 0x3;
+        value[19] = HexDigits[variant | 0x8];
+
+        return Guid(std::move(value));
+    }
 }

--- a/Engine/Source/Tbx/Layers/LayerManager.cpp
+++ b/Engine/Source/Tbx/Layers/LayerManager.cpp
@@ -36,35 +36,71 @@ namespace Tbx
         return nullptr;
     }
 
+    std::vector<Tbx::Ref<Layer>> LayerManager::GetLayers() const
+    {
+        std::vector<Tbx::Ref<Layer>> layers = {};
+        for (auto& layer : _stack)
+        {
+            if (layer)
+            {
+                layers.push_back(layer);
+            }
+        }
+
+        return layers;
+    }
+
     void LayerManager::AddLayer(const Tbx::Ref<Layer>& layer)
     {
+        if (!layer)
+        {
+            TBX_TRACE_ERROR("LayerManager: Attempted to add an invalid layer instance.");
+            return;
+        }
+
+        const auto existing = GetLayer(layer->GetName());
+        if (existing)
+        {
+            TBX_TRACE_ERROR("LayerManager: A layer named {} is already registered.", layer->GetName());
+            return;
+        }
+
         _stack.Push(layer);
     }
 
     void LayerManager::RemoveLayer(Tbx::uint index)
     {
         auto layer = GetLayer(index);
-        if (layer)
+        if (!layer)
         {
-            _stack.Remove(layer);
+            TBX_TRACE_ERROR("LayerManager: Failed to remove layer at index {} because it does not exist.", index);
+            return;
         }
+
+        _stack.Remove(layer);
     }
 
     void LayerManager::RemoveLayer(const std::string& name)
     {
         auto layer = GetLayer(name);
-        if (layer)
+        if (!layer)
         {
-            _stack.Remove(layer);
+            TBX_TRACE_ERROR("LayerManager: Failed to remove layer named {} because it does not exist.", name);
+            return;
         }
+
+        _stack.Remove(layer);
     }
 
     void LayerManager::RemoveLayer(const Tbx::Ref<Layer>& layer)
     {
-        if (layer)
+        if (!layer)
         {
-            _stack.Remove(layer);
+            TBX_TRACE_ERROR("LayerManager: Attempted to remove an invalid layer instance.");
+            return;
         }
+
+        _stack.Remove(layer);
     }
 
     void LayerManager::ClearLayers()

--- a/Engine/Source/Tbx/Layers/LayerStack.cpp
+++ b/Engine/Source/Tbx/Layers/LayerStack.cpp
@@ -1,6 +1,5 @@
 #include "Tbx/PCH.h"
 #include "Tbx/Layers/LayerStack.h"
-
 namespace Tbx
 {
     LayerStack::~LayerStack()

--- a/Engine/Source/Tbx/Layers/RenderingLayer.cpp
+++ b/Engine/Source/Tbx/Layers/RenderingLayer.cpp
@@ -1,121 +1,31 @@
 #include "Tbx/PCH.h"
 #include "Tbx/Layers/RenderingLayer.h"
-#include "Tbx/Graphics/FrameBufferBuilder.h"
-#include "Tbx/Events/EventBus.h"
-#include "Tbx/Events/RenderEvents.h"
+#include <memory>
 
 namespace Tbx
 {
-    RenderingLayer::RenderingLayer(
-        Tbx::Ref<IRendererFactory> renderFactory,
-        Tbx::Ref<EventBus> eventBus) : Layer("Rendering")
+    RenderingLayer::RenderingLayer(Tbx::Ref<IRendererFactory> renderFactory, Tbx::Ref<EventBus> eventBus)
+        : Layer("Rendering")
     {
-        _renderFactory = renderFactory;
-        _eventBus = eventBus;
-
-        _eventBus->Subscribe(this, &RenderingLayer::OnWindowOpened);
-        _eventBus->Subscribe(this, &RenderingLayer::OnWindowClosed);
-        _eventBus->Subscribe(this, &RenderingLayer::OnAppSettingsChanged);
-    }
-
-    void RenderingLayer::OnUpdate()
-    {
-        DrawFrame();
-    }
-
-    void RenderingLayer::DrawFrame()
-    {
-        // TODO: add support for world layers!
-        // TODO: properly compress all stages into a single frame buffer
-        for (auto stage : _openStages)
-        {
-            
-            // Gather all boxes from the current world
-            const Tbx::Ref<Toy> spaceRoot = stage->GetRoot();
-
-            if (_firstFrame) // TODO: We need to do this any time we add a new renderer or toy...
-            {
-                // Pre-process the opened box using the frame buffer builder
-                FrameBufferBuilder builder;
-                const auto buffer = builder.BuildUploadBuffer(spaceRoot);
-
-                // Send buffer to renderers for each window
-                for (const auto& renderer : _renderers)
-                {
-                    renderer->Flush();
-                    renderer->Process(buffer);
-                }
-
-                // Flip first frame flag to off
-                _firstFrame = false;
-            }
-
-            // Build a frame buffer of render commands for the world
-            FrameBufferBuilder builder;
-            const auto buffer = builder.BuildRenderBuffer(spaceRoot);
-
-            // Send buffer to renderers for each window
-            int rendererIndex = 0;
-            for (const auto& renderer : _renderers)
-            {
-                auto rendererWindow = _windows[rendererIndex];
-                renderer->SetViewport({ {0, 0}, rendererWindow->GetSize() });
-                renderer->Clear(_clearColor);
-                renderer->Process(buffer);
-                rendererIndex++;
-            }
-
-            // Send our frame rendered event so anything can hook into our rendering and do post work...
-            _eventBus->Send(RenderedFrameEvent());
-
-            // Swap the buffers for each window after a frame is rendered
-            for (const auto& window : _windows)
-            {
-                window->SwapBuffers();
-            }
-        }
+        _rendering = std::make_unique<Rendering>(renderFactory, eventBus);
     }
 
     Tbx::Ref<IRenderer> RenderingLayer::GetRenderer(const Tbx::Ref<IWindow>& window)
     {
-        auto it = std::find(_windows.begin(), _windows.end(), window);
-        if (it == _windows.end())
+        if (!_rendering)
         {
-            TBX_ASSERT(false, "No renderer found for window");
             return nullptr;
         }
-        auto index = static_cast<size_t>(std::distance(_windows.begin(), it));
-        return _renderers[index];
+
+        return _rendering->GetRenderer(window);
     }
 
-    void RenderingLayer::OnWindowOpened(const WindowOpenedEvent& e)
+    void RenderingLayer::OnUpdate()
     {
-        auto newWindow = e.GetWindow();
-        TBX_ASSERT(_renderFactory, "Render factory plugin was unloaded! Cannot create new renderer");
-
-        auto newRenderer = _renderFactory->Create(newWindow);
-        _windows.push_back(newWindow);
-        _renderers.push_back(newRenderer);
-    }
-
-    void RenderingLayer::OnWindowClosed(const WindowClosedEvent& e)
-    {
-        auto window = e.GetWindow();
-        auto it = std::find(_windows.begin(), _windows.end(), window);
-        if (it != _windows.end())
+        if (_rendering)
         {
-            auto index = static_cast<size_t>(std::distance(_windows.begin(), it));
-            _windows.erase(_windows.begin() + index);
-            if (index < _renderers.size())
-            {
-                _renderers.erase(_renderers.begin() + index);
-            }
+            _rendering->Update();
         }
-    }
-
-    void RenderingLayer::OnAppSettingsChanged(const AppSettingsChangedEvent& e)
-    {
-        _clearColor = e.GetNewSettings().ClearColor;
     }
 }
 


### PR DESCRIPTION
## Summary
- document the App interface, remove public layer-manager exposure, and enforce layer/window runtime access through assertions
- update LayerManager to log invalid operations instead of returning bools and ensure duplicate registrations fail gracefully
- factor renderer submission into Rendering::FlushRenderBuffer while reusing the existing upload path

## Testing
- cmake -S . -B build *(fails: required dependency and plugin directories are absent in this workspace clone)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1a2ac79c83278313f02cc4474f08