### PR TITLE
Add graphics context interfaces for rendering initialization

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -1,0 +1,57 @@
+#pragma once
+#include "Tbx/DllExport.h"
+#include "Tbx/Graphics/GraphicsApi.h"
+#include "Tbx/Memory/Refs.h"
+
+namespace Tbx
+{
+    class Window;
+
+    /// <summary>
+    /// Represents a graphics context responsible for bootstrapping and managing a rendering API.
+    /// </summary>
+    class TBX_EXPORT IGraphicsContext
+    {
+    public:
+        virtual ~IGraphicsContext() = default;
+
+        /// <summary>
+        /// Initializes the underlying graphics backend and prepares the context for use.
+        /// </summary>
+        virtual void Initialize() = 0;
+
+        /// <summary>
+        /// Releases the resources owned by the context.
+        /// </summary>
+        virtual void Shutdown() = 0;
+
+        /// <summary>
+        /// Makes the context active on the current thread.
+        /// </summary>
+        virtual void MakeCurrent() = 0;
+
+        /// <summary>
+        /// Presents the rendered contents to the screen.
+        /// </summary>
+        virtual void SwapBuffers() = 0;
+
+        /// <summary>
+        /// Returns the graphics API supported by this context.
+        /// </summary>
+        virtual GraphicsApi GetApi() const = 0;
+    };
+
+    /// <summary>
+    /// Creates graphics contexts for a given window and graphics API.
+    /// </summary>
+    class TBX_EXPORT IGraphicsContextProvider
+    {
+    public:
+        virtual ~IGraphicsContextProvider() = default;
+
+        /// <summary>
+        /// Creates a graphics context for the provided window using the requested API.
+        /// </summary>
+        virtual Ref<IGraphicsContext> Create(const Ref<Window>& window, GraphicsApi api) = 0;
+    };
+}


### PR DESCRIPTION
## Summary
- add a generic `IGraphicsContext` interface to manage initialization and lifecycle of graphics backends
- introduce an `IGraphicsContextProvider` interface for creating contexts for specific windows and APIs

## Testing
- not run (header-only change)


------
https://chatgpt.com/codex/tasks/task_e_68dc3f1af4cc8327a9e6e10522f0ec16