### PR TITLE
Add block collection tests and align stage view coverage

### DIFF
--- a/Engine/Tests/Events/EventBusTests.cpp
+++ b/Engine/Tests/Events/EventBusTests.cpp
@@ -104,6 +104,7 @@ namespace Tbx::Tests::Events
             EventSuppressor suppressor;
             bus.Post(DummyEvent("Suppressed"));
             bus.Send(DummyEvent("Suppressed"));
+            bus.Flush();
         }
 
         bus.Flush();

--- a/Engine/Tests/Events/EventBusTests.cpp
+++ b/Engine/Tests/Events/EventBusTests.cpp
@@ -1,0 +1,114 @@
+#include "PCH.h"
+#include "Tbx/Events/EventBus.h"
+#include <string>
+#include <vector>
+
+namespace Tbx::Tests::Events
+{
+    class DummyEvent final : public Event
+    {
+    public:
+        explicit DummyEvent(std::string message)
+            : _message(std::move(message))
+        {
+        }
+
+        std::string ToString() const override { return _message; }
+
+    private:
+        std::string _message;
+    };
+
+    TEST(EventBusTests, SubscribeAndSend_InvokesCallback)
+    {
+        // Arrange
+        EventBus bus;
+        bool invoked = false;
+
+        bus.Subscribe<DummyEvent>([&](Event& evt)
+        {
+            invoked = true;
+            auto& dummy = static_cast<DummyEvent&>(evt);
+            EXPECT_EQ(dummy.ToString(), "Hello");
+            dummy.IsHandled = true;
+        });
+
+        // Act
+        const bool handled = bus.Send(DummyEvent("Hello"));
+
+        // Assert
+        EXPECT_TRUE(invoked);
+        EXPECT_TRUE(handled);
+    }
+
+    TEST(EventBusTests, Unsubscribe_RemovesListener)
+    {
+        // Arrange
+        EventBus bus;
+        bool invoked = false;
+
+        const auto token = bus.Subscribe<DummyEvent>([&](Event&)
+        {
+            invoked = true;
+        });
+
+        // Act
+        bus.Unsubscribe(token);
+        const bool handled = bus.Send(DummyEvent("Ignored"));
+
+        // Assert
+        EXPECT_FALSE(invoked);
+        EXPECT_FALSE(handled);
+    }
+
+    TEST(EventBusTests, PostAndFlush_DeliversQueuedEventsInOrder)
+    {
+        // Arrange
+        EventBus bus;
+        std::vector<std::string> messages;
+
+        bus.Subscribe<DummyEvent>([&](Event& evt)
+        {
+            auto& dummy = static_cast<DummyEvent&>(evt);
+            messages.push_back(dummy.ToString());
+        });
+
+        bus.Post(DummyEvent("First"));
+        bus.Post(DummyEvent("Second"));
+        bus.Post(DummyEvent("Third"));
+
+        // Act
+        bus.Flush();
+        bus.Flush(); // ensure queue is empty after the first flush
+
+        // Assert
+        ASSERT_EQ(messages.size(), 3u);
+        EXPECT_EQ(messages[0], "First");
+        EXPECT_EQ(messages[1], "Second");
+        EXPECT_EQ(messages[2], "Third");
+    }
+
+    TEST(EventBusTests, Suppressor_PreventsDispatch)
+    {
+        // Arrange
+        EventBus bus;
+        bool invoked = false;
+
+        bus.Subscribe<DummyEvent>([&](Event&)
+        {
+            invoked = true;
+        });
+
+        // Act
+        {
+            EventSuppressor suppressor;
+            bus.Post(DummyEvent("Suppressed"));
+            bus.Send(DummyEvent("Suppressed"));
+        }
+
+        bus.Flush();
+
+        // Assert
+        EXPECT_FALSE(invoked);
+    }
+}

--- a/Engine/Tests/Stages/BlockCollectionTests.cpp
+++ b/Engine/Tests/Stages/BlockCollectionTests.cpp
@@ -1,0 +1,55 @@
+#include "PCH.h"
+#include "Tbx/Stages/Blocks.h"
+#include "Tbx/Math/Transform.h"
+#include "Tbx/Math/Vectors.h"
+#include "Tbx/Graphics/Mesh.h"
+
+namespace Tbx::Tests::Stages
+{
+    TEST(BlockCollectionTests, AddAndGet_ReturnsStoredBlock)
+    {
+        BlockCollection blocks;
+
+        auto& transform = blocks.Add<Transform>();
+        transform.SetPosition({ 1.0f, 2.0f, 3.0f });
+
+        ASSERT_TRUE(blocks.Contains<Transform>());
+
+        const auto& stored = blocks.Get<Transform>();
+        EXPECT_FLOAT_EQ(stored.Position.X, 1.0f);
+        EXPECT_FLOAT_EQ(stored.Position.Y, 2.0f);
+        EXPECT_FLOAT_EQ(stored.Position.Z, 3.0f);
+
+        const BlockCollection& constBlocks = blocks;
+        const auto& constStored = constBlocks.Get<Transform>();
+        EXPECT_FLOAT_EQ(constStored.Position.X, 1.0f);
+        EXPECT_FLOAT_EQ(constStored.Position.Y, 2.0f);
+        EXPECT_FLOAT_EQ(constStored.Position.Z, 3.0f);
+    }
+
+    TEST(BlockCollectionTests, Remove_ErasesStoredBlock)
+    {
+        BlockCollection blocks;
+
+        blocks.Add<Mesh>();
+        ASSERT_TRUE(blocks.Contains<Mesh>());
+
+        EXPECT_NO_THROW(blocks.Remove<Mesh>());
+        EXPECT_FALSE(blocks.Contains<Mesh>());
+
+        EXPECT_NO_THROW(blocks.Remove<Mesh>());
+    }
+
+    TEST(BlockCollectionTests, Add_ReplacesExistingInstance)
+    {
+        BlockCollection blocks;
+
+        blocks.Add<Transform>().SetPosition({ 1.0f, 0.0f, 0.0f });
+        blocks.Add<Transform>().SetPosition({ 2.0f, 0.0f, 0.0f });
+
+        const auto& transform = blocks.Get<Transform>();
+        EXPECT_FLOAT_EQ(transform.Position.X, 2.0f);
+        EXPECT_FLOAT_EQ(transform.Position.Y, 0.0f);
+        EXPECT_FLOAT_EQ(transform.Position.Z, 0.0f);
+    }
+}

--- a/Engine/Tests/Stages/StageTests.cpp
+++ b/Engine/Tests/Stages/StageTests.cpp
@@ -1,0 +1,60 @@
+#include "PCH.h"
+#include "Tbx/Stages/Stage.h"
+#include "Tbx/Stages/Toy.h"
+#include "Tbx/Memory/Refs.h"
+
+namespace Tbx::Tests::Stages
+{
+    class CountingToy : public Toy
+    {
+    public:
+        using Toy::Toy;
+
+        void OnUpdate() override
+        {
+            ++UpdateCount;
+        }
+
+        int UpdateCount = 0;
+    };
+
+    TEST(StageTests, Constructor_CreatesRootToy)
+    {
+        // Act
+        Stage stage;
+
+        // Assert
+        auto root = stage.GetRoot();
+        ASSERT_NE(root, nullptr);
+        EXPECT_EQ(root->Handle.Name, "Root");
+    }
+
+    TEST(StageTests, Update_PropagatesToChildren)
+    {
+        // Arrange
+        Stage stage;
+        auto child = MakeRef<CountingToy>("Child");
+        stage.GetRoot()->Children.push_back(child);
+
+        // Act
+        stage.Update();
+
+        // Assert
+        EXPECT_EQ(child->UpdateCount, 1);
+    }
+
+    TEST(StageTests, Update_SkipsDisabledChildren)
+    {
+        // Arrange
+        Stage stage;
+        auto child = MakeRef<CountingToy>("Child");
+        child->Enabled = false;
+        stage.GetRoot()->Children.push_back(child);
+
+        // Act
+        stage.Update();
+
+        // Assert
+        EXPECT_EQ(child->UpdateCount, 0);
+    }
+}

--- a/Engine/Tests/Stages/StageViewTests.cpp
+++ b/Engine/Tests/Stages/StageViewTests.cpp
@@ -1,0 +1,99 @@
+#include "PCH.h"
+#include "Tbx/Stages/Stage.h"
+#include "Tbx/Stages/Views.h"
+#include "Tbx/Stages/Blocks.h"
+#include "Tbx/Math/Transform.h"
+#include "Tbx/Graphics/Mesh.h"
+#include "Tbx/Memory/Refs.h"
+#include <string>
+#include <vector>
+
+namespace Tbx::Tests::Stages
+{
+    TEST(StageViewTests, IteratesAllToysWhenNoFilter)
+    {
+        // Arrange
+        Stage stage;
+        auto root = stage.GetRoot();
+        auto childA = MakeRef<Toy>("ChildA");
+        auto childB = MakeRef<Toy>("ChildB");
+        auto grandChild = MakeRef<Toy>("GrandChild");
+
+        childA->Children.push_back(grandChild);
+        root->Children.push_back(childA);
+        root->Children.push_back(childB);
+
+        // Act
+        StageView<> view(root);
+        std::vector<std::string> names;
+        for (const auto& toy : view)
+        {
+            names.push_back(toy->Handle.Name);
+        }
+
+        // Assert
+        ASSERT_EQ(names.size(), 4u);
+        EXPECT_EQ(names[0], "Root");
+        EXPECT_EQ(names[1], "ChildA");
+        EXPECT_EQ(names[2], "GrandChild");
+        EXPECT_EQ(names[3], "ChildB");
+    }
+
+    TEST(StageViewTests, FiltersToysByBlockType)
+    {
+        // Arrange
+        Stage stage;
+        auto root = stage.GetRoot();
+        auto childA = MakeRef<Toy>("ChildA");
+        auto childB = MakeRef<Toy>("ChildB");
+        auto grandChild = MakeRef<Toy>("GrandChild");
+
+        childA->Blocks.Add<Transform>();
+        childB->Blocks.Add<Mesh>();
+        grandChild->Blocks.Add<Mesh>();
+
+        childA->Children.push_back(grandChild);
+        root->Children.push_back(childA);
+        root->Children.push_back(childB);
+
+        // Act
+        StageView<Mesh> view(root);
+        std::vector<std::string> names;
+        for (const auto& toy : view)
+        {
+            names.push_back(toy->Handle.Name);
+        }
+
+        // Assert
+        ASSERT_EQ(names.size(), 2u);
+        EXPECT_EQ(names[0], "GrandChild");
+        EXPECT_EQ(names[1], "ChildB");
+    }
+
+    TEST(StageViewTests, IncludesToysMatchingAnyRequestedBlock)
+    {
+        // Arrange
+        Stage stage;
+        auto root = stage.GetRoot();
+        auto childA = MakeRef<Toy>("ChildA");
+        auto childB = MakeRef<Toy>("ChildB");
+
+        childA->Blocks.Add<Transform>();
+        childB->Blocks.Add<Mesh>();
+
+        root->Children.push_back(childA);
+        root->Children.push_back(childB);
+
+        // Act
+        StageView<Transform, Mesh> view(root);
+        std::vector<std::string> names;
+        for (const auto& toy : view)
+        {
+            names.push_back(toy->Handle.Name);
+        }
+
+        // Assert
+        ASSERT_EQ(names.size(), 2u);
+        EXPECT_THAT(names, ::testing::ElementsAre("ChildA", "ChildB"));
+    }
+}

--- a/Engine/Tests/Stages/StageViewTests.cpp
+++ b/Engine/Tests/Stages/StageViewTests.cpp
@@ -5,6 +5,7 @@
 #include "Tbx/Math/Transform.h"
 #include "Tbx/Graphics/Mesh.h"
 #include "Tbx/Memory/Refs.h"
+#include <gmock/gmock.h>
 #include <string>
 #include <vector>
 

--- a/Engine/Tests/Stages/ToyTests.cpp
+++ b/Engine/Tests/Stages/ToyTests.cpp
@@ -1,0 +1,77 @@
+#include "PCH.h"
+#include "Tbx/Stages/Toy.h"
+#include "Tbx/Memory/Refs.h"
+
+namespace Tbx::Tests::Stages
+{
+    class CountingToy : public Toy
+    {
+    public:
+        using Toy::Toy;
+
+        void OnUpdate() override
+        {
+            ++UpdateCount;
+        }
+
+        int UpdateCount = 0;
+    };
+
+    TEST(ToyTests, Constructor_AssignsNameToHandle)
+    {
+        // Act
+        CountingToy toy("Player");
+
+        // Assert
+        EXPECT_EQ(toy.Handle.Name, "Player");
+        EXPECT_TRUE(toy.Enabled);
+    }
+
+    TEST(ToyTests, Update_CallsOnUpdateWhenEnabled)
+    {
+        // Arrange
+        auto parent = MakeRef<CountingToy>("Parent");
+        auto child = MakeRef<CountingToy>("Child");
+        parent->Children.push_back(child);
+
+        // Act
+        parent->Update();
+
+        // Assert
+        EXPECT_EQ(parent->UpdateCount, 1);
+        EXPECT_EQ(child->UpdateCount, 1);
+    }
+
+    TEST(ToyTests, Update_SkipsWhenDisabled)
+    {
+        // Arrange
+        auto parent = MakeRef<CountingToy>("Parent");
+        auto child = MakeRef<CountingToy>("Child");
+        child->Enabled = false;
+        parent->Children.push_back(child);
+
+        // Act
+        parent->Enabled = false;
+        parent->Update();
+
+        // Assert
+        EXPECT_EQ(parent->UpdateCount, 0);
+        EXPECT_EQ(child->UpdateCount, 0);
+    }
+
+    TEST(ToyTests, Update_StillSkipsDisabledChildren)
+    {
+        // Arrange
+        auto parent = MakeRef<CountingToy>("Parent");
+        auto child = MakeRef<CountingToy>("Child");
+        child->Enabled = false;
+        parent->Children.push_back(child);
+
+        // Act
+        parent->Update();
+
+        // Assert
+        EXPECT_EQ(parent->UpdateCount, 1);
+        EXPECT_EQ(child->UpdateCount, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- scope the dummy event directly within the tests namespace to address feedback about empty namespaces
- update stage view tests to use existing Transform and Mesh blocks when filtering
- add block collection unit tests covering retrieval, removal, and replacement scenarios
- inline stage helper toy subclasses directly within their surrounding test namespaces to avoid anonymous wrappers

## Testing
- `cmake -S . -B build` *(fails: dependency and plugin submodules are absent in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3fe36a5083278fd07e2eb299ae68