### PR TITLE
Streamline renderer backend selection

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -44,10 +44,10 @@ namespace Tbx
     /// <summary>
     /// Creates graphics contexts for a given window and graphics API.
     /// </summary>
-    class TBX_EXPORT IGraphicsContextProvider
+    class TBX_EXPORT IGraphicsConfigProvider
     {
     public:
-        virtual ~IGraphicsContextProvider() = default;
+        virtual ~IGraphicsConfigProvider() = default;
 
         /// <summary>
         /// Creates a graphics context for the provided window using the requested API.

--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -16,16 +16,6 @@ namespace Tbx
         virtual ~IGraphicsConfig() = default;
 
         /// <summary>
-        /// Initializes the underlying graphics backend and prepares the context for use.
-        /// </summary>
-        virtual void Initialize() = 0;
-
-        /// <summary>
-        /// Releases the resources owned by the context.
-        /// </summary>
-        virtual void Shutdown() = 0;
-
-        /// <summary>
         /// Makes the context active on the current thread.
         /// </summary>
         virtual void MakeCurrent() = 0;

--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -10,10 +10,10 @@ namespace Tbx
     /// <summary>
     /// Represents a graphics context responsible for bootstrapping and managing a rendering API.
     /// </summary>
-    class TBX_EXPORT IGraphicsContext
+    class TBX_EXPORT IGraphicsConfig
     {
     public:
-        virtual ~IGraphicsContext() = default;
+        virtual ~IGraphicsConfig() = default;
 
         /// <summary>
         /// Initializes the underlying graphics backend and prepares the context for use.
@@ -52,6 +52,6 @@ namespace Tbx
         /// <summary>
         /// Creates a graphics context for the provided window using the requested API.
         /// </summary>
-        virtual Ref<IGraphicsContext> Create(const Ref<Window>& window, GraphicsApi api) = 0;
+        virtual Ref<IGraphicsConfig> Create(const Ref<Window>& window, GraphicsApi api) = 0;
     };
 }

--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -40,8 +40,8 @@ namespace Tbx
         virtual ~IGraphicsConfigProvider() = default;
 
         /// <summary>
-        /// Creates a graphics context for the provided window using the requested API.
+        /// Retrieves a graphics context for the provided window using the requested API.
         /// </summary>
-        virtual Ref<IGraphicsConfig> Create(const Ref<Window>& window, GraphicsApi api) = 0;
+        virtual Ref<IGraphicsConfig> Get(const Ref<Window>& window, GraphicsApi api) = 0;
     };
 }

--- a/Engine/Include/Tbx/Graphics/RenderCommands.h
+++ b/Engine/Include/Tbx/Graphics/RenderCommands.h
@@ -72,7 +72,7 @@ namespace Tbx
     {
     public:
         RenderCommandBuffer BuildUploadBuffer(StageView<MaterialInstance, Mesh, Model> view);
-        RenderCommandBuffer BuildRenderBuffer(FullStageViewView view);
+        RenderCommandBuffer BuildRenderBuffer(FullStageViewView view, float aspectRatio);
 
     private:
         void AddToyUploadCommandsToBuffer(const Ref<Toy>& toy, RenderCommandBuffer& buffer);

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -73,13 +73,12 @@ namespace Tbx
 
         void OnWindowOpened(const WindowOpenedEvent& e);
         void OnWindowClosed(const WindowClosedEvent& e);
-        void OnWindowResized(const WindowResizedEvent& e);
         void OnAppSettingsChanged(const AppSettingsChangedEvent& e);
         void OnStageOpened(const StageOpenedEvent& e);
         void OnStageClosed(const StageClosedEvent& e);
 
         Ref<IRenderer> CreateRenderer(GraphicsApi api);
-        Ref<IGraphicsConfig> CreateContext(const Ref<Window>& window, GraphicsApi api);
+        Ref<IGraphicsConfig> GetConfig(const Ref<Window>& window, GraphicsApi api);
         void RecreateRenderersForCurrentApi();
 
         RenderingContext* FindBinding(const Ref<Window>& window);

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -18,27 +18,12 @@ namespace Tbx
 {
     struct RenderingContext
     {
+        Ref<Window> Window = nullptr;
         Ref<IGraphicsConfig> Config = nullptr;
         Ref<IRenderer> Renderer = nullptr;
     };
 
-    struct WindowRefHash
-    {
-        size_t operator()(const Ref<Window>& window) const noexcept
-        {
-            return std::hash<Window*>{}(window.get());
-        }
-    };
-
-    struct WindowRefEqual
-    {
-        bool operator()(const Ref<Window>& lhs, const Ref<Window>& rhs) const noexcept
-        {
-            return lhs.get() == rhs.get();
-        }
-    };
-
-    using WindowBindingMap = std::unordered_map<Ref<Window>, RenderingContext, WindowRefHash, WindowRefEqual>;
+    using WindowBindingMap = std::unordered_map<Window*, RenderingContext>;
 
     /// <summary>
     /// Coordinates render targets, windows, and stage composition for a frame.
@@ -81,15 +66,14 @@ namespace Tbx
         Ref<IGraphicsConfig> GetConfig(const Ref<Window>& window, GraphicsApi api);
         void RecreateRenderersForCurrentApi();
 
-        RenderingContext* FindBinding(const Ref<Window>& window);
-        const RenderingContext* FindBinding(const Ref<Window>& window) const;
-
     private:
         std::vector<Ref<Stage>> _openStages = {};
         WindowBindingMap _windowBindings = {};
         std::vector<Ref<Stage>> _pendingUploadStages = {};
-        std::unordered_map<GraphicsApi, std::vector<Ref<IRendererFactory>>> _rendererFactoryCache = {};
-        std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsConfigProvider>>> _contextProviderCache = {};
+        std::vector<Ref<IRendererFactory>> _rendererFactories = {};
+        std::vector<Ref<IGraphicsConfigProvider>> _graphicsConfigProviders = {};
+        std::unordered_map<GraphicsApi, Ref<IRendererFactory>> _rendererFactoryCache = {};
+        std::unordered_map<GraphicsApi, Ref<IGraphicsConfigProvider>> _configProviderCache = {};
         Ref<EventBus> _eventBus = nullptr;
         EventListener _eventListener = {};
         GraphicsApi _graphicsApi = GraphicsApi::OpenGL;

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -65,9 +65,12 @@ namespace Tbx
         Ref<IGraphicsConfig> CreateContext(const Ref<Window>& window, GraphicsApi api);
         void RecreateRenderersForCurrentApi();
 
+        RenderingContext* FindBinding(const Ref<Window>& window);
+        const RenderingContext* FindBinding(const Ref<Window>& window) const;
+
     private:
         std::vector<Ref<Stage>> _openStages = {};
-        std::vector<RenderingContext> _windowBindings = {};
+        std::unordered_map<Window*, RenderingContext> _windowBindings = {};
         std::vector<Ref<Stage>> _pendingUploadStages = {};
         std::unordered_map<GraphicsApi, std::vector<Ref<IRendererFactory>>> _rendererFactoryCache = {};
         std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsConfigProvider>>> _contextProviderCache = {};

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -18,10 +18,27 @@ namespace Tbx
 {
     struct RenderingContext
     {
-        Ref<Window> BoundWindow = nullptr;
         Ref<IGraphicsConfig> Config = nullptr;
         Ref<IRenderer> Renderer = nullptr;
     };
+
+    struct WindowRefHash
+    {
+        size_t operator()(const Ref<Window>& window) const noexcept
+        {
+            return std::hash<Window*>{}(window.get());
+        }
+    };
+
+    struct WindowRefEqual
+    {
+        bool operator()(const Ref<Window>& lhs, const Ref<Window>& rhs) const noexcept
+        {
+            return lhs.get() == rhs.get();
+        }
+    };
+
+    using WindowBindingMap = std::unordered_map<Ref<Window>, RenderingContext, WindowRefHash, WindowRefEqual>;
 
     /// <summary>
     /// Coordinates render targets, windows, and stage composition for a frame.
@@ -70,7 +87,7 @@ namespace Tbx
 
     private:
         std::vector<Ref<Stage>> _openStages = {};
-        std::unordered_map<Window*, RenderingContext> _windowBindings = {};
+        WindowBindingMap _windowBindings = {};
         std::vector<Ref<Stage>> _pendingUploadStages = {};
         std::unordered_map<GraphicsApi, std::vector<Ref<IRendererFactory>>> _rendererFactoryCache = {};
         std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsConfigProvider>>> _contextProviderCache = {};

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -22,7 +22,7 @@ namespace Tbx
         Ref<IRenderer> Renderer = nullptr;
     };
 
-    using WindowBindingMap = std::unordered_map<Ref<Window>, RenderingContext, WindowRefHasher, WindowRefEqual>;
+    using WindowBindingMap = std::unordered_map<Ref<Window>, RenderingContext, RefHasher<Window>, RefEqual<Window>>;
 
     /// <summary>
     /// Coordinates render targets, windows, and stage composition for a frame.

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -16,6 +16,13 @@
 
 namespace Tbx
 {
+    struct RenderingContext
+    {
+        Ref<Window> Window = nullptr;
+        Ref<IGraphicsConfig> Config = nullptr;
+        Ref<IRenderer> Renderer = nullptr;
+    };
+
     /// <summary>
     /// Coordinates render targets, windows, and stage composition for a frame.
     /// </summary>
@@ -54,25 +61,16 @@ namespace Tbx
         void OnStageOpened(const StageOpenedEvent& e);
         void OnStageClosed(const StageClosedEvent& e);
 
-        struct WindowBinding
-        {
-            Ref<Window> Window = nullptr;
-            Ref<IGraphicsContext> Context = nullptr;
-            Ref<IRenderer> Renderer = nullptr;
-        };
-
         Ref<IRenderer> CreateRenderer(GraphicsApi api);
-        Ref<IGraphicsContext> CreateContext(const Ref<Window>& window, GraphicsApi api);
+        Ref<IGraphicsConfig> CreateContext(const Ref<Window>& window, GraphicsApi api);
         void RecreateRenderersForCurrentApi();
 
     private:
         std::vector<Ref<Stage>> _openStages = {};
-        std::vector<WindowBinding> _windowBindings = {};
+        std::vector<RenderingContext> _windowBindings = {};
         std::vector<Ref<Stage>> _pendingUploadStages = {};
-        std::vector<Ref<IRendererFactory>> _rendererFactories = {};
-        std::vector<Ref<IGraphicsContextProvider>> _graphicsContextProviders = {};
-        std::unordered_map<GraphicsApi, Ref<IRendererFactory>> _rendererFactoryCache = {};
-        std::unordered_map<GraphicsApi, Ref<IGraphicsContextProvider>> _contextProviderCache = {};
+        std::unordered_map<GraphicsApi, std::vector<Ref<IRendererFactory>>> _rendererFactoryCache = {};
+        std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsContextProvider>>> _contextProviderCache = {};
         Ref<EventBus> _eventBus = nullptr;
         EventListener _eventListener = {};
         GraphicsApi _graphicsApi = GraphicsApi::OpenGL;

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -11,7 +11,6 @@
 #include "Tbx/Events/WindowEvents.h"
 #include "Tbx/Memory/Refs.h"
 #include "Tbx/Graphics/Color.h"
-#include <functional>
 #include <unordered_map>
 #include <vector>
 
@@ -21,22 +20,6 @@ namespace Tbx
     {
         Ref<IGraphicsConfig> Config = nullptr;
         Ref<IRenderer> Renderer = nullptr;
-    };
-
-    struct WindowRefHasher
-    {
-        size_t operator()(const Ref<Window>& window) const noexcept
-        {
-            return std::hash<const Window*>()(window.get());
-        }
-    };
-
-    struct WindowRefEqual
-    {
-        bool operator()(const Ref<Window>& lhs, const Ref<Window>& rhs) const noexcept
-        {
-            return lhs.get() == rhs.get();
-        }
     };
 
     using WindowBindingMap = std::unordered_map<Ref<Window>, RenderingContext, WindowRefHasher, WindowRefEqual>;

--- a/Engine/Include/Tbx/Graphics/Rendering.h
+++ b/Engine/Include/Tbx/Graphics/Rendering.h
@@ -18,7 +18,7 @@ namespace Tbx
 {
     struct RenderingContext
     {
-        Ref<Window> Window = nullptr;
+        Ref<Window> BoundWindow = nullptr;
         Ref<IGraphicsConfig> Config = nullptr;
         Ref<IRenderer> Renderer = nullptr;
     };
@@ -31,7 +31,7 @@ namespace Tbx
     public:
         Rendering(
             const std::vector<Ref<IRendererFactory>>& rendererFactories,
-            const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
+            const std::vector<Ref<IGraphicsConfigProvider>>& graphicsContextProviders,
             Ref<EventBus> eventBus);
         ~Rendering();
 
@@ -70,7 +70,7 @@ namespace Tbx
         std::vector<RenderingContext> _windowBindings = {};
         std::vector<Ref<Stage>> _pendingUploadStages = {};
         std::unordered_map<GraphicsApi, std::vector<Ref<IRendererFactory>>> _rendererFactoryCache = {};
-        std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsContextProvider>>> _contextProviderCache = {};
+        std::unordered_map<GraphicsApi, std::vector<Ref<IGraphicsConfigProvider>>> _contextProviderCache = {};
         Ref<EventBus> _eventBus = nullptr;
         EventListener _eventListener = {};
         GraphicsApi _graphicsApi = GraphicsApi::OpenGL;

--- a/Engine/Include/Tbx/Memory/Refs.h
+++ b/Engine/Include/Tbx/Memory/Refs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 #include <memory>
 #include <type_traits>
 
@@ -45,4 +46,61 @@ namespace Tbx
 
     template <typename U>
     struct IsRef<ExclusiveRef<U>> : std::true_type {};
+
+    template <typename T>
+    struct RefHasher
+    {
+        size_t operator()(const Ref<T>& ref) const noexcept
+        {
+            return std::hash<const T*>()(ref.get());
+        }
+    };
+
+    template <typename T>
+    struct RefEqual
+    {
+        bool operator()(const Ref<T>& lhs, const Ref<T>& rhs) const noexcept
+        {
+            return lhs.get() == rhs.get();
+        }
+    };
+
+    template <typename T>
+    struct ExclusiveRefHasher
+    {
+        size_t operator()(const ExclusiveRef<T>& ref) const noexcept
+        {
+            return std::hash<const T*>()(ref.get());
+        }
+    };
+
+    template <typename T>
+    struct ExclusiveRefEqual
+    {
+        bool operator()(const ExclusiveRef<T>& lhs, const ExclusiveRef<T>& rhs) const noexcept
+        {
+            return lhs.get() == rhs.get();
+        }
+    };
+
+    template <typename T>
+    struct WeakRefHasher
+    {
+        size_t operator()(const WeakRef<T>& ref) const noexcept
+        {
+            auto locked = ref.lock();
+            return std::hash<const T*>()(locked.get());
+        }
+    };
+
+    template <typename T>
+    struct WeakRefEqual
+    {
+        bool operator()(const WeakRef<T>& lhs, const WeakRef<T>& rhs) const noexcept
+        {
+            auto lhsLocked = lhs.lock();
+            auto rhsLocked = rhs.lock();
+            return lhsLocked.get() == rhsLocked.get();
+        }
+    };
 }

--- a/Engine/Include/Tbx/Windowing/Window.h
+++ b/Engine/Include/Tbx/Windowing/Window.h
@@ -4,7 +4,6 @@
 #include "Tbx/Math/Size.h"
 #include "Tbx/Events/EventBus.h"
 #include <any>
-#include <functional>
 
 namespace Tbx
 {
@@ -46,22 +45,6 @@ namespace Tbx
 
     public:
         Uid Id = Uid::Generate();
-    };
-
-    struct WindowRefHasher
-    {
-        size_t operator()(const Ref<Window>& window) const noexcept
-        {
-            return std::hash<const Window*>()(window.get());
-        }
-    };
-
-    struct WindowRefEqual
-    {
-        bool operator()(const Ref<Window>& lhs, const Ref<Window>& rhs) const noexcept
-        {
-            return lhs.get() == rhs.get();
-        }
     };
 
     class TBX_EXPORT IWindowFactory

--- a/Engine/Include/Tbx/Windowing/Window.h
+++ b/Engine/Include/Tbx/Windowing/Window.h
@@ -4,6 +4,7 @@
 #include "Tbx/Math/Size.h"
 #include "Tbx/Events/EventBus.h"
 #include <any>
+#include <functional>
 
 namespace Tbx
 {
@@ -45,6 +46,22 @@ namespace Tbx
 
     public:
         Uid Id = Uid::Generate();
+    };
+
+    struct WindowRefHasher
+    {
+        size_t operator()(const Ref<Window>& window) const noexcept
+        {
+            return std::hash<const Window*>()(window.get());
+        }
+    };
+
+    struct WindowRefEqual
+    {
+        bool operator()(const Ref<Window>& lhs, const Ref<Window>& rhs) const noexcept
+        {
+            return lhs.get() == rhs.get();
+        }
     };
 
     class TBX_EXPORT IWindowFactory

--- a/Engine/Source/Tbx/App/App.cpp
+++ b/Engine/Source/Tbx/App/App.cpp
@@ -1,6 +1,7 @@
 #include "Tbx/PCH.h"
 #include "Tbx/App/App.h"
 #include "Tbx/App/Runtime.h"
+#include "Tbx/Graphics/GraphicsContext.h"
 #include "Tbx/Layers/InputLayer.h"
 #include "Tbx/Layers/RenderingLayer.h"
 #include "Tbx/Layers/WindowingLayer.h"
@@ -89,11 +90,11 @@ namespace Tbx
             }
 
             auto rendererFactoryPlugs = _plugins.OfType<IRendererFactory>();
+            auto graphicsContextProviders = _plugins.OfType<IGraphicsContextProvider>();
+
             if (!rendererFactoryPlugs.empty())
             {
-                TBX_ASSERT(rendererFactoryPlugs.size() == 1, "App: Only one renderer factory is allowed!");
-                auto rendererFactory = rendererFactoryPlugs.front();
-                AddLayer<RenderingLayer>(rendererFactory, _eventBus);
+                AddLayer<RenderingLayer>(rendererFactoryPlugs, graphicsContextProviders, _eventBus);
             }
 
             auto inputHandlerPlugs = _plugins.OfType<IInputHandler>();

--- a/Engine/Source/Tbx/App/App.cpp
+++ b/Engine/Source/Tbx/App/App.cpp
@@ -90,7 +90,7 @@ namespace Tbx
             }
 
             auto rendererFactoryPlugs = _plugins.OfType<IRendererFactory>();
-            auto graphicsContextProviders = _plugins.OfType<IGraphicsContextProvider>();
+            auto graphicsContextProviders = _plugins.OfType<IGraphicsConfigProvider>();
 
             if (!rendererFactoryPlugs.empty())
             {

--- a/Engine/Source/Tbx/Graphics/RenderCommand.cpp
+++ b/Engine/Source/Tbx/Graphics/RenderCommand.cpp
@@ -34,6 +34,7 @@ namespace Tbx
 
             auto& camera = toy->Blocks.Get<Camera>();
 
+            TBX_ASSERT(aspectRatio > 0.0f, "RenderCommandBufferBuilder: aspect ratio must be positive.");
             if (aspectRatio > 0.0f)
             {
                 camera.SetAspect(aspectRatio);

--- a/Engine/Source/Tbx/Graphics/RenderCommand.cpp
+++ b/Engine/Source/Tbx/Graphics/RenderCommand.cpp
@@ -21,7 +21,7 @@ namespace Tbx
         return buffer;
     }
 
-    RenderCommandBuffer RenderCommandBufferBuilder::BuildRenderBuffer(FullStageViewView view)
+    RenderCommandBuffer RenderCommandBufferBuilder::BuildRenderBuffer(FullStageViewView view, float aspectRatio)
     {
         // Build view frustums from cameras
         auto frustums = std::vector<Frustum>();
@@ -33,6 +33,11 @@ namespace Tbx
             }
 
             auto& camera = toy->Blocks.Get<Camera>();
+
+            if (aspectRatio > 0.0f)
+            {
+                camera.SetAspect(aspectRatio);
+            }
 
             Vector3 camPos = Vector3::Zero;
             Quaternion camRot = Quaternion::Identity;

--- a/Engine/Source/Tbx/Graphics/Rendering.cpp
+++ b/Engine/Source/Tbx/Graphics/Rendering.cpp
@@ -13,7 +13,7 @@ namespace Tbx
 {
     Rendering::Rendering(
         const std::vector<Ref<IRendererFactory>>& rendererFactories,
-        const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
+        const std::vector<Ref<IGraphicsConfigProvider>>& graphicsContextProviders,
         Ref<EventBus> eventBus)
         : _eventBus(eventBus)
         , _eventListener(eventBus)
@@ -87,7 +87,7 @@ namespace Tbx
         auto it = std::find_if(_windowBindings.begin(), _windowBindings.end(),
             [&window](const RenderingContext& binding)
             {
-                return binding.Window == window;
+                return binding.BoundWindow == window;
             });
         if (it == _windowBindings.end())
         {
@@ -200,7 +200,7 @@ namespace Tbx
         for (auto& binding : _windowBindings)
         {
             const auto& renderer = binding.Renderer;
-            const auto& rendererWindow = binding.Window;
+            const auto& rendererWindow = binding.BoundWindow;
             const auto& config = binding.Config;
             if (!renderer || !rendererWindow)
             {
@@ -311,7 +311,7 @@ namespace Tbx
         auto it = std::find_if(_windowBindings.begin(), _windowBindings.end(),
             [&closedWindow](const RenderingContext& binding)
             {
-                return binding.Window == closedWindow;
+                return binding.BoundWindow == closedWindow;
             });
         if (it != _windowBindings.end())
         {
@@ -332,7 +332,7 @@ namespace Tbx
         auto bindingIt = std::find_if(_windowBindings.begin(), _windowBindings.end(),
             [&resizedWindow](const RenderingContext& binding)
             {
-                return binding.Window == resizedWindow;
+                return binding.BoundWindow == resizedWindow;
             });
         if (bindingIt != _windowBindings.end())
         {
@@ -394,7 +394,7 @@ namespace Tbx
 
         for (const auto& binding : _windowBindings)
         {
-            const auto& window = binding.Window;
+            const auto& window = binding.BoundWindow;
             if (!window)
             {
                 newBindings.push_back({ nullptr, nullptr, nullptr });

--- a/Engine/Source/Tbx/Layers/RenderingLayer.cpp
+++ b/Engine/Source/Tbx/Layers/RenderingLayer.cpp
@@ -6,7 +6,7 @@ namespace Tbx
 {
     RenderingLayer::RenderingLayer(
         const std::vector<Ref<IRendererFactory>>& renderFactories,
-        const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
+        const std::vector<Ref<IGraphicsConfigProvider>>& graphicsContextProviders,
         Ref<EventBus> eventBus)
         : Layer("Rendering")
     {

--- a/Engine/Source/Tbx/Layers/RenderingLayer.cpp
+++ b/Engine/Source/Tbx/Layers/RenderingLayer.cpp
@@ -4,10 +4,13 @@
 
 namespace Tbx
 {
-    RenderingLayer::RenderingLayer(Ref<IRendererFactory> renderFactory, Ref<EventBus> eventBus)
+    RenderingLayer::RenderingLayer(
+        const std::vector<Ref<IRendererFactory>>& renderFactories,
+        const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
+        Ref<EventBus> eventBus)
         : Layer("Rendering")
     {
-        _rendering = MakeExclusive<Rendering>(renderFactory, eventBus);
+        _rendering = MakeExclusive<Rendering>(renderFactories, graphicsContextProviders, eventBus);
     }
 
     void RenderingLayer::OnUpdate()

--- a/Engine/Source/Tbx/Layers/RenderingLayer.h
+++ b/Engine/Source/Tbx/Layers/RenderingLayer.h
@@ -2,9 +2,11 @@
 #include "Tbx/DllExport.h"
 #include "Tbx/Layers/Layer.h"
 #include "Tbx/Graphics/IRenderer.h"
+#include "Tbx/Graphics/GraphicsContext.h"
 #include "Tbx/Graphics/Rendering.h"
 #include "Tbx/Events/EventBus.h"
 #include "Tbx/Memory/Refs.h"
+#include <vector>
 
 namespace Tbx
 {
@@ -15,7 +17,8 @@ namespace Tbx
     {
     public:
         TBX_EXPORT RenderingLayer(
-            Ref<IRendererFactory> renderFactory,
+            const std::vector<Ref<IRendererFactory>>& renderFactories,
+            const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
             Ref<EventBus> eventBus);
 
     protected:

--- a/Engine/Source/Tbx/Layers/RenderingLayer.h
+++ b/Engine/Source/Tbx/Layers/RenderingLayer.h
@@ -18,7 +18,7 @@ namespace Tbx
     public:
         TBX_EXPORT RenderingLayer(
             const std::vector<Ref<IRendererFactory>>& renderFactories,
-            const std::vector<Ref<IGraphicsContextProvider>>& graphicsContextProviders,
+            const std::vector<Ref<IGraphicsConfigProvider>>& graphicsContextProviders,
             Ref<EventBus> eventBus);
 
     protected:

--- a/Engine/Tests/Graphics/FrameBufferBuilderTests.cpp
+++ b/Engine/Tests/Graphics/FrameBufferBuilderTests.cpp
@@ -72,7 +72,7 @@ namespace Tbx::Tests::Graphics
 
         // Act
         RenderCommandBufferBuilder builder;
-        RenderCommandBuffer buffer = builder.BuildRenderBuffer(toy);
+        RenderCommandBuffer buffer = builder.BuildRenderBuffer(toy, 1.0f);
 
         // Assert
         EXPECT_TRUE(buffer.Commands.empty());
@@ -99,7 +99,7 @@ namespace Tbx::Tests::Graphics
 
         // Act
         RenderCommandBufferBuilder builder;
-        RenderCommandBuffer buffer = builder.BuildRenderBuffer(root);
+        RenderCommandBuffer buffer = builder.BuildRenderBuffer(root, 1.0f);
 
         // Assert
         const auto& cmds = buffer.Commands;


### PR DESCRIPTION
## Summary
- manage renderers and graphics contexts per window through a binding struct and cache backend providers per graphics API
- rebuild per-window contexts and renderers when the graphics API changes while relying on backend asserts instead of manual init/shutdown
- defer validation of graphics context providers to the rendering subsystem during app initialization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc6685641483279863f9996ab9a8dd