### PR TITLE
Let rendering layer validate graphics plugins

### DIFF
--- a/Engine/Include/Tbx/App/Settings.h
+++ b/Engine/Include/Tbx/App/Settings.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "Tbx/DllExport.h"
 #include "Tbx/Graphics/Color.h"
-#include "Tbx/Graphics/GraphicsContext.h"
+#include "Tbx/Graphics/GraphicsApi.h"
 #include "Tbx/Math/Size.h"
 
 namespace Tbx

--- a/Engine/Include/Tbx/Graphics/GraphicsApi.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsApi.h
@@ -1,11 +1,8 @@
 #pragma once
 #include "Tbx/DllExport.h"
-#include "Tbx/Graphics/Viewport.h"
 
 namespace Tbx
 {
-    class IGraphicsContext;
-
     enum class TBX_EXPORT GraphicsApi
     {
         None,
@@ -13,29 +10,5 @@ namespace Tbx
         OpenGL,
         Metal,
         Custom
-    };
-
-    /// <summary>
-    /// Says something uses graphics apis.
-    /// Is resposible for providing what Apis it supports.
-    /// </summary>
-    class TBX_EXPORT IUseGraphicsApis
-    {
-    public:
-        virtual ~IUseGraphicsApis() = default;
-        virtual std::vector<GraphicsApi> GetSupportedApis() const = 0;
-    };
- 
-    /// <summary>
-    /// Says something is responsible for a graphics api.
-    /// It handles initialization and shutdown of the api.
-    /// </summary>
-    class TBX_EXPORT IManageGraphicsApis : public IUseGraphicsApis
-    {
-    public:
-        virtual ~IManageGraphicsApis() = default;
-        virtual void Initialize(Ref<IGraphicsContext> context, GraphicsApi api) = 0;
-        virtual void Shutdown() = 0;
-
     };
 }

--- a/Engine/Include/Tbx/Graphics/GraphicsBackend.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsBackend.h
@@ -30,14 +30,9 @@ namespace Tbx
         virtual GraphicsApi GetApi() const = 0;
 
         /// <summary>
-        /// Performs API specific initialization for the provided context.
+        /// Sets the graphics context used for rendering operations.
         /// </summary>
-        virtual void Initialize(Ref<IGraphicsContext> context) = 0;
-
-        /// <summary>
-        /// Shuts down the backend and releases API resources.
-        /// </summary>
-        virtual void Shutdown() = 0;
+        virtual void SetContext(Ref<IGraphicsContext> context) = 0;
 
         /// <summary>
         /// Begins drawing to the active render target using the provided viewport.

--- a/Engine/Include/Tbx/Graphics/GraphicsBackend.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsBackend.h
@@ -1,0 +1,72 @@
+#pragma once
+#include "Tbx/DllExport.h"
+#include "Tbx/Graphics/Color.h"
+#include "Tbx/Graphics/GraphicsApi.h"
+#include "Tbx/Graphics/Viewport.h"
+#include "Tbx/Memory/Refs.h"
+#include <vector>
+
+namespace Tbx
+{
+    class IGraphicsContext;
+    struct Shader;
+    struct Texture;
+    struct Mesh;
+    class ShaderResource;
+    class TextureResource;
+    class MeshResource;
+
+    /// <summary>
+    /// Represents a concrete graphics API implementation responsible for managing device resources.
+    /// </summary>
+    class TBX_EXPORT IGraphicsBackend
+    {
+    public:
+        virtual ~IGraphicsBackend() = default;
+
+        /// <summary>
+        /// Identifies the graphics API handled by this backend.
+        /// </summary>
+        virtual GraphicsApi GetApi() const = 0;
+
+        /// <summary>
+        /// Performs API specific initialization for the provided context.
+        /// </summary>
+        virtual void Initialize(Ref<IGraphicsContext> context) = 0;
+
+        /// <summary>
+        /// Shuts down the backend and releases API resources.
+        /// </summary>
+        virtual void Shutdown() = 0;
+
+        /// <summary>
+        /// Begins drawing to the active render target using the provided viewport.
+        /// </summary>
+        virtual void BeginDraw(const Viewport& viewport) = 0;
+
+        /// <summary>
+        /// Finalizes drawing for the active render target and applies the provided clear color.
+        /// </summary>
+        virtual void EndDraw(const RgbaColor& clearColor) = 0;
+
+        /// <summary>
+        /// Creates a shader program resource ready for rendering.
+        /// </summary>
+        virtual Ref<ShaderResource> CreateResource(const std::vector<Ref<Shader>>& shaderProgram) = 0;
+
+        /// <summary>
+        /// Creates a GPU texture resource for the provided texture asset.
+        /// </summary>
+        virtual Ref<TextureResource> CreateResource(const Ref<Texture>& texture) = 0;
+
+        /// <summary>
+        /// Creates a GPU mesh resource for the provided mesh asset.
+        /// </summary>
+        virtual Ref<MeshResource> CreateResource(const Ref<Mesh>& mesh) = 0;
+
+        /// <summary>
+        /// Compiles the provided shaders so they are ready for GPU upload.
+        /// </summary>
+        virtual void CompileShaders(const std::vector<Ref<Shader>>& shaders) = 0;
+    };
+}

--- a/Engine/Include/Tbx/Graphics/GraphicsContext.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsContext.h
@@ -7,7 +7,15 @@ namespace Tbx
 {
     class Window;
 
-    using ProcAddressFunPtr = void*;
+    /// <summary>
+    /// Represents the available vertical sync modes for a graphics context swap chain.
+    /// </summary>
+    enum class VsyncMode
+    {
+        Off,
+        On,
+        Adaptive
+    };
 
     /// <summary>
     /// Represents a graphics context responsible for managing a windows rendering.
@@ -18,11 +26,6 @@ namespace Tbx
         virtual ~IGraphicsContext() = default;
 
         /// <summary>
-        /// Gets the function pointer used to load graphics functions at runtime;
-        /// </summary>
-        virtual ProcAddressFunPtr GetProcAddressLoader() = 0;
-
-        /// <summary>
         /// Makes the context active on the current thread.
         /// </summary>
         virtual void MakeCurrent() = 0;
@@ -30,45 +33,31 @@ namespace Tbx
         /// <summary>
         /// Presents the rendered contents to the screen.
         /// </summary>
-        virtual void SwapBuffers() = 0;
+        virtual void Present() = 0;
 
         /// <summary>
-        /// Sets the swap interval for the context.
+        /// Sets the vsync mode for the context.
         /// </summary>
-        virtual void SetSwapInterval(int interval) = 0;
+        virtual void SetVsync(VsyncMode mode) = 0;
 
-        /// <summary>
-        /// Sets the viewport for the context.
-        /// </summary>
-        virtual void SetViewport(const Viewport& viewport) = 0;
-
-        /// <summary>
-        /// Sets the resolution for the context.
-        /// </summary>
-        virtual void SetResolution(const Size& resolution) = 0;
-
-        /// <summary>
-        /// Sets the clear color for the context.
-        /// </summary>
-        virtual void SetClearColor(const RgbaColor& color) = 0;
-
-        /// <summary>
-        /// Clears the contexts surface with the current clear color.
-        /// </summary>
-        virtual void Clear() = 0;
     };
 
     /// <summary>
     /// Creates graphics contexts for a given window and graphics API.
     /// </summary>
-    class TBX_EXPORT IGraphicsContextProvider : public IUseGraphicsApis
+    class TBX_EXPORT IGraphicsContextProvider
     {
     public:
         virtual ~IGraphicsContextProvider() = default;
 
         /// <summary>
-        /// Provides a graphics context for the provided window using the requested API.
+        /// Identifies the graphics API handled by this provider.
         /// </summary>
-        virtual Ref<IGraphicsContext> Provide(Ref<Window> window, GraphicsApi api) = 0;
+        virtual GraphicsApi GetApi() const = 0;
+
+        /// <summary>
+        /// Provides a graphics context for the provided window using the provider's API.
+        /// </summary>
+        virtual Ref<IGraphicsContext> Provide(Ref<Window> window) = 0;
     };
 }

--- a/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Tbx/DllExport.h"
+#include "Tbx/Graphics/GraphicsBackend.h"
 #include "Tbx/Graphics/GraphicsContext.h"
 #include "Tbx/Graphics/GraphicsResource.h"
 #include "Tbx/Graphics/Frustum.h"
@@ -39,11 +40,9 @@ namespace Tbx
 
     struct GraphicsRenderer
     {
-        Ref<IManageGraphicsApis> ApiManager = nullptr;
+        Ref<IGraphicsBackend> Backend = nullptr;
         Ref<IGraphicsContextProvider> ContextProvider = nullptr;
-        Ref<IGraphicsResourceFactory> ResourceFactory = nullptr;
-        Ref<IShaderCompiler> ShaderCompiler = nullptr;
-        GraphicsResourceCache ResourceCache = {};
+        GraphicsResourceCache Cache = {};
     };
 
     /// <summary>
@@ -53,10 +52,8 @@ namespace Tbx
     {
     public:
         GraphicsPipeline(
-            const std::vector<Ref<IManageGraphicsApis>>& apiManagers,
-            const std::vector<Ref<IGraphicsResourceFactory>>& resourceFactories,
+            const std::vector<Ref<IGraphicsBackend>>& backends,
             const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
-            const std::vector<Ref<IShaderCompiler>>& shaderCompilers,
             Ref<EventBus> eventBus);
         ~GraphicsPipeline();
 
@@ -71,7 +68,7 @@ namespace Tbx
         /// <summary>
         /// Iterates active displays and stages to prepare resources before presenting each surface.
         /// </summary>
-        void RenderOpenStages(const Ref<GraphicsRenderer>& renderer);
+        void RenderOpenStages(GraphicsRenderer& renderer);
 
         /// <summary>
         /// Checks whether a toy lies outside all active view frustums and should be skipped.
@@ -80,13 +77,14 @@ namespace Tbx
         void AddStage(const Ref<Stage>& stage);
         void RemoveStage(const Ref<Stage>& stage);
 
-        bool TryGetRenderer(GraphicsApi api, Ref<GraphicsRenderer>& renderer);
+        bool TryGetRenderer(GraphicsApi api, GraphicsRenderer*& renderer);
+        bool TryGetRenderer(GraphicsApi api, const GraphicsRenderer*& renderer) const;
         void RecreateRenderersForCurrentApi();
 
-        void CompileShaders(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Shader>>& shaders);
-        void CacheShaders(const Ref<GraphicsRenderer>& renderer, const Material& material);
-        void CacheTextures(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Texture>>& textures);
-        void CacheMeshes(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Mesh>>& meshes);
+        void CompileShaders(const std::vector<Ref<Shader>>& shaders);
+        void CacheShaders(GraphicsRenderer& renderer, const Material& material);
+        void CacheTextures(GraphicsRenderer& renderer, const std::vector<Ref<Texture>>& textures);
+        void CacheMeshes(GraphicsRenderer& renderer, const std::vector<Ref<Mesh>>& meshes);
 
         void OnAppSettingsChanged(const AppSettingsChangedEvent& e);
         void OnWindowOpened(const WindowOpenedEvent& e);
@@ -97,14 +95,13 @@ namespace Tbx
     private:
         std::vector<Ref<Stage>> _openStages = {};
         std::vector<GraphicsDisplay> _openDisplays = {};
-        std::unordered_map<GraphicsApi, Ref<GraphicsRenderer>> _renderers = {};
+        std::unordered_map<GraphicsApi, GraphicsRenderer> _renderers = {};
 
         Ref<EventBus> _eventBus = nullptr;
         EventListener _eventListener = {};
 
-        GraphicsApi _currApi = GraphicsApi::None;
+        GraphicsApi _activeGraphicsApi = GraphicsApi::None;
         RgbaColor _clearColor = {};
-        Size _resolution = {};
     };
 }
 

--- a/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
@@ -77,8 +77,7 @@ namespace Tbx
         void AddStage(const Ref<Stage>& stage);
         void RemoveStage(const Ref<Stage>& stage);
 
-        bool TryGetRenderer(GraphicsApi api, GraphicsRenderer*& renderer);
-        bool TryGetRenderer(GraphicsApi api, const GraphicsRenderer*& renderer) const;
+        GraphicsRenderer* TryGetRenderer(GraphicsApi api);
         void RecreateRenderersForCurrentApi();
 
         void CompileShaders(const std::vector<Ref<Shader>>& shaders);

--- a/Engine/Include/Tbx/Graphics/GraphicsResource.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsResource.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "Tbx/Graphics/GraphicsApi.h"
 #include "Tbx/Graphics/Shader.h"
 #include "Tbx/Graphics/Texture.h"
 #include "Tbx/Graphics/Mesh.h"
@@ -58,12 +57,4 @@ namespace Tbx
         Ref<GraphicsResource> _resource;
     };
 
-    class TBX_EXPORT IGraphicsResourceFactory : public IUseGraphicsApis
-    {
-    public:
-        virtual ~IGraphicsResourceFactory() = default;
-        virtual Ref<ShaderResource> Create(std::vector<Ref<Shader>> shaderProgram) = 0;
-        virtual Ref<TextureResource> Create(Ref<Texture> texture) = 0;
-        virtual Ref<MeshResource> Create(Ref<Mesh> mesh) = 0;
-    };
 }

--- a/Engine/Include/Tbx/Graphics/Shader.h
+++ b/Engine/Include/Tbx/Graphics/Shader.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "Tbx/DllExport.h"
-#include "Tbx/Graphics/GraphicsApi.h"
 #include "Tbx/Graphics/Color.h"
 #include "Tbx/Math/Mat4x4.h"
 #include "Tbx/Ids/Uid.h"
@@ -45,7 +44,7 @@ namespace Tbx
     /// <summary>
     /// Compiles a shader.
     /// </summary>
-    class TBX_EXPORT IShaderCompiler : public IUseGraphicsApis
+    class TBX_EXPORT IShaderCompiler
     {
     public:
         virtual ~IShaderCompiler() = default;
@@ -54,6 +53,6 @@ namespace Tbx
         /// Compiles a shader.
         /// Returns true on success and false on failure.
         /// </summary>
-        virtual bool Compile(Ref<Shader> shader, GraphicsApi targetApi) = 0;
+        virtual bool Compile(Ref<Shader> shader) = 0;
     };
 }

--- a/Engine/Source/Tbx/App/App.cpp
+++ b/Engine/Source/Tbx/App/App.cpp
@@ -4,6 +4,7 @@
 #include "Tbx/App/Layers/InputLayer.h"
 #include "Tbx/App/Layers/RenderingLayer.h"
 #include "Tbx/App/Layers/WindowingLayer.h"
+#include "Tbx/Graphics/GraphicsBackend.h"
 #include "Tbx/Graphics/GraphicsContext.h"
 #include "Tbx/Assets/AssetServer.h"
 #include "Tbx/Events/AppEvents.h"
@@ -11,6 +12,7 @@
 #include "Tbx/Input/InputCodes.h"
 #include "Tbx/Time/DeltaTime.h"
 #include "Tbx/Files/Paths.h"
+#include <vector>
 #include <stdexcept>
 
 namespace Tbx
@@ -91,14 +93,9 @@ namespace Tbx
                 Layers.Add<WindowingLayer>(appName, windowFactory, Dispatcher);
             }
 
-            auto apiManagers = Plugins.OfType<IManageGraphicsApis>();
-            auto rendererFactoryPlugs = Plugins.OfType<IGraphicsResourceFactory>();
-            auto graphicsContextProviders = Plugins.OfType<IGraphicsContextProvider>();
-            auto shaderCompilers = Plugins.OfType<IShaderCompiler>();
-            if (!apiManagers.empty())
-            {
-                Layers.Add<RenderingLayer>(apiManagers, rendererFactoryPlugs, graphicsContextProviders, shaderCompilers, Dispatcher);
-            }
+            auto graphicsBackends = Plugins.OfType<IGraphicsBackend>();
+            auto contextProviders = Plugins.OfType<IGraphicsContextProvider>();
+            Layers.Add<RenderingLayer>(graphicsBackends, contextProviders, Dispatcher);
 
             auto inputHandlerPlugs = Plugins.OfType<IInputHandler>();
             if (!inputHandlerPlugs.empty())

--- a/Engine/Source/Tbx/App/Layers/RenderingLayer.cpp
+++ b/Engine/Source/Tbx/App/Layers/RenderingLayer.cpp
@@ -5,14 +5,12 @@
 namespace Tbx
 {
     RenderingLayer::RenderingLayer(
-        const std::vector<Ref<IManageGraphicsApis>>& apiManagers,
-        const std::vector<Ref<IGraphicsResourceFactory>>& resourceFactories,
+        const std::vector<Ref<IGraphicsBackend>>& backends,
         const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
-        const std::vector<Ref<IShaderCompiler>>& shaderCompilers,
         Ref<EventBus> eventBus)
         : Layer("Rendering")
     {
-        _pipeline = MakeExclusive<GraphicsPipeline>(apiManagers, resourceFactories, contextProviders, shaderCompilers, eventBus);
+        _pipeline = MakeExclusive<GraphicsPipeline>(backends, contextProviders, eventBus);
     }
 
     void RenderingLayer::OnUpdate()

--- a/Engine/Source/Tbx/App/Layers/RenderingLayer.h
+++ b/Engine/Source/Tbx/App/Layers/RenderingLayer.h
@@ -16,10 +16,8 @@ namespace Tbx
     {
     public:
         TBX_EXPORT RenderingLayer(
-            const std::vector<Ref<IManageGraphicsApis>>& apiManagers,
-            const std::vector<Ref<IGraphicsResourceFactory>>& resourceFactories,
+            const std::vector<Ref<IGraphicsBackend>>& backends,
             const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
-            const std::vector<Ref<IShaderCompiler>>& shaderCompilers,
             Ref<EventBus> eventBus);
 
     protected:

--- a/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
@@ -485,7 +485,7 @@ namespace Tbx
         {
             if (renderer.Backend)
             {
-                renderer.Backend->Shutdown();
+                renderer.Backend->SetContext(nullptr);
             }
 
             renderer.Cache.Clear();
@@ -518,7 +518,7 @@ namespace Tbx
                 continue;
             }
 
-            renderer->Backend->Initialize(context);
+            renderer->Backend->SetContext(context);
             display.Context = context;
         }
     }
@@ -724,7 +724,7 @@ namespace Tbx
             return;
         }
 
-        renderer->Backend->Initialize(context);
+        renderer->Backend->SetContext(context);
 
         if (displayIt != _openDisplays.end())
         {
@@ -759,7 +759,7 @@ namespace Tbx
             GraphicsRenderer* renderer = nullptr;
             if (TryGetRenderer(_activeGraphicsApi, renderer) && renderer && renderer->Backend)
             {
-                renderer->Backend->Shutdown();
+                renderer->Backend->SetContext(nullptr);
                 renderer->Cache.Clear();
             }
         }

--- a/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
@@ -218,8 +218,8 @@ namespace Tbx
 
     void GraphicsPipeline::DrawFrame()
     {
-        GraphicsRenderer* renderer = nullptr;
-        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend)
+        GraphicsRenderer* renderer = TryGetRenderer(_activeGraphicsApi);
+        if (!renderer || !renderer->Backend)
         {
             return;
         }
@@ -496,8 +496,8 @@ namespace Tbx
             display.Context = nullptr;
         }
 
-        GraphicsRenderer* renderer = nullptr;
-        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend || !renderer->ContextProvider)
+        GraphicsRenderer* renderer = TryGetRenderer(_activeGraphicsApi);
+        if (!renderer || !renderer->Backend || !renderer->ContextProvider)
         {
             return;
         }
@@ -530,7 +530,7 @@ namespace Tbx
             return;
         }
 
-        auto* renderer = FindRenderer(_activeGraphicsApi);
+        auto* renderer = TryGetRenderer(_activeGraphicsApi);
         if (!renderer || !renderer->Backend)
         {
             return;
@@ -666,8 +666,8 @@ namespace Tbx
         _clearColor = newSettings.ClearColor;
         auto desiredApi = newSettings.RenderingApi;
 
-        const GraphicsRenderer* desiredRenderer = nullptr;
-        const bool rendererAvailable = TryGetRenderer(desiredApi, desiredRenderer) && desiredRenderer && desiredRenderer->Backend && desiredRenderer->ContextProvider;
+        const GraphicsRenderer* desiredRenderer = TryGetRenderer(desiredApi);
+        const bool rendererAvailable = desiredRenderer && desiredRenderer->Backend && desiredRenderer->ContextProvider;
         if (!rendererAvailable)
         {
             GraphicsApi fallbackApi = GraphicsApi::None;
@@ -701,8 +701,8 @@ namespace Tbx
             return;
         }
 
-        GraphicsRenderer* renderer = nullptr;
-        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend)
+        GraphicsRenderer* renderer = TryGetRenderer(_activeGraphicsApi);
+        if (!renderer || !renderer->Backend)
         {
             return;
         }
@@ -756,8 +756,8 @@ namespace Tbx
 
         if (_openDisplays.empty())
         {
-            GraphicsRenderer* renderer = nullptr;
-            if (TryGetRenderer(_activeGraphicsApi, renderer) && renderer && renderer->Backend)
+            GraphicsRenderer* renderer = TryGetRenderer(_activeGraphicsApi);
+            if (renderer && renderer->Backend)
             {
                 renderer->Backend->SetContext(nullptr);
                 renderer->Cache.Clear();
@@ -775,40 +775,20 @@ namespace Tbx
         RemoveStage(e.GetStage());
     }
 
-    bool GraphicsPipeline::TryGetRenderer(GraphicsApi api, GraphicsRenderer*& renderer)
+    GraphicsRenderer* GraphicsPipeline::TryGetRenderer(GraphicsApi api)
     {
-        renderer = nullptr;
         if (api == GraphicsApi::None)
         {
-            return false;
+            return nullptr;
         }
 
         auto rendererIt = _renderers.find(api);
         if (rendererIt == _renderers.end())
         {
-            return false;
+            return nullptr;
         }
 
-        renderer = &rendererIt->second;
-        return true;
-    }
-
-    bool GraphicsPipeline::TryGetRenderer(GraphicsApi api, const GraphicsRenderer*& renderer) const
-    {
-        renderer = nullptr;
-        if (api == GraphicsApi::None)
-        {
-            return false;
-        }
-
-        auto rendererIt = _renderers.find(api);
-        if (rendererIt == _renderers.end())
-        {
-            return false;
-        }
-
-        renderer = &rendererIt->second;
-        return true;
+        return &rendererIt->second;
     }
 }
 

--- a/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
@@ -133,74 +133,71 @@ namespace Tbx
     }
 
     GraphicsPipeline::GraphicsPipeline(
-        const std::vector<Ref<IManageGraphicsApis>>& apiManagers,
-        const std::vector<Ref<IGraphicsResourceFactory>>& resourceFactories,
+        const std::vector<Ref<IGraphicsBackend>>& backends,
         const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
-        const std::vector<Ref<IShaderCompiler>>& shaderCompilers,
         Ref<EventBus> eventBus)
         : _eventBus(eventBus)
         , _eventListener(eventBus)
     {
-        TBX_ASSERT(!resourceFactories.empty(), "Rendering: requires at least one renderer factory instance.");
-        TBX_ASSERT(!contextProviders.empty(), "Rendering: requires at least one graphics context provider instance.");
-        TBX_ASSERT(!shaderCompilers.empty(), "Rendering: requires at least one shader compiler instance.");
+        TBX_ASSERT(!backends.empty(), "Rendering: requires at least one graphics backend instance.");
         TBX_ASSERT(_eventBus, "Rendering: requires a valid event bus instance.");
 
-        auto findSupporting = [](const auto& providers, GraphicsApi api)
+        for (const auto& backend : backends)
         {
-            using ProviderType = typename std::decay_t<decltype(providers)>::value_type::element_type;
-            Ref<ProviderType> result = nullptr;
-            auto it = std::find_if(providers.begin(), providers.end(), [api](const auto& candidate)
-            {
-                if (!candidate)
-                {
-                    return false;
-                }
-
-                const auto supportedApis = candidate->GetSupportedApis();
-                return std::find(supportedApis.begin(), supportedApis.end(), api) != supportedApis.end();
-            });
-
-            if (it != providers.end())
-            {
-                result = *it;
-            }
-
-            return result;
-        };
-
-        for (const auto& manager : apiManagers)
-        {
-            if (!manager)
+            if (!backend)
             {
                 continue;
             }
 
-            const auto supportedApis = manager->GetSupportedApis();
-            for (auto supportedApi : supportedApis)
+            const auto api = backend->GetApi();
+            if (api == GraphicsApi::None)
             {
-                if (_renderers.contains(supportedApi))
-                {
-                    continue;
-                }
-
-                auto resourceFactory = findSupporting(resourceFactories, supportedApi);
-                auto contextProvider = findSupporting(contextProviders, supportedApi);
-                auto shaderCompiler = findSupporting(shaderCompilers, supportedApi);
-
-                if (!resourceFactory || !contextProvider || !shaderCompiler)
-                {
-                    continue;
-                }
-
-                auto renderer = MakeRef<GraphicsRenderer>();
-                renderer->ApiManager = manager;
-                renderer->ResourceFactory = resourceFactory;
-                renderer->ContextProvider = contextProvider;
-                renderer->ShaderCompiler = shaderCompiler;
-
-                _renderers.emplace(supportedApi, renderer);
+                continue;
             }
+
+            auto& renderer = _renderers[api];
+            if (!renderer.Backend)
+            {
+                renderer.Backend = backend;
+            }
+        }
+
+        for (const auto& provider : contextProviders)
+        {
+            if (!provider)
+            {
+                continue;
+            }
+
+            const auto api = provider->GetApi();
+            if (api == GraphicsApi::None)
+            {
+                continue;
+            }
+
+            auto rendererIt = _renderers.find(api);
+            if (rendererIt == _renderers.end())
+            {
+                continue;
+            }
+
+            auto& renderer = rendererIt->second;
+            if (!renderer.ContextProvider)
+            {
+                renderer.ContextProvider = provider;
+            }
+        }
+
+        for (auto it = _renderers.begin(); it != _renderers.end();)
+        {
+            auto& renderer = it->second;
+            if (!renderer.Backend || !renderer.ContextProvider)
+            {
+                it = _renderers.erase(it);
+                continue;
+            }
+
+            ++it;
         }
 
         _eventListener.Listen(this, &GraphicsPipeline::OnWindowOpened);
@@ -221,17 +218,22 @@ namespace Tbx
 
     void GraphicsPipeline::DrawFrame()
     {
-        Ref<GraphicsRenderer> renderer = nullptr;
-        if (!TryGetRenderer(_currApi, renderer) || !renderer)
+        GraphicsRenderer* renderer = nullptr;
+        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend)
         {
             return;
         }
 
-        RenderOpenStages(renderer);
+        RenderOpenStages(*renderer);
     }
 
-    void GraphicsPipeline::RenderOpenStages(const Ref<GraphicsRenderer>& renderer)
+    void GraphicsPipeline::RenderOpenStages(GraphicsRenderer& renderer)
     {
+        if (!renderer.Backend)
+        {
+            return;
+        }
+
         for (const auto& display : _openDisplays)
         {
             if (!display.Surface || !display.Context)
@@ -241,10 +243,7 @@ namespace Tbx
 
             // Bind the display surface and prepare a clear framebuffer before processing stages.
             display.Context->MakeCurrent();
-            display.Context->SetViewport({ {0, 0}, display.Surface->GetSize() });
-            display.Context->SetResolution(display.Surface->GetSize());
-            display.Context->SetClearColor(_clearColor);
-            display.Context->Clear();
+            renderer.Backend->BeginDraw({ {0, 0}, display.Surface->GetSize() });
 
             auto aspectRatio = CalculateAspectRatioFromSize(display.Surface->GetSize());
 
@@ -284,10 +283,10 @@ namespace Tbx
                     }
 
                     const auto* representativeMaterial = bucket.front().MaterialBlock;
-                    const bool shaderCached = renderer && renderer->ResourceCache.Shaders.contains(shaderProgramId);
+                    const bool shaderCached = renderer.Cache.Shaders.contains(shaderProgramId);
                     if (representativeMaterial && representativeMaterial->ShaderProgram && !shaderCached)
                     {
-                        CompileShaders(renderer, representativeMaterial->ShaderProgram->Shaders);
+                        CompileShaders(representativeMaterial->ShaderProgram->Shaders);
                         CacheShaders(renderer, *representativeMaterial);
                     }
 
@@ -334,13 +333,8 @@ namespace Tbx
                         CacheMeshes(renderer, meshesToCache);
                     }
 
-                    if (!renderer)
-                    {
-                        continue;
-                    }
-
-                    const auto shaderResourceIt = renderer->ResourceCache.Shaders.find(shaderProgramId);
-                    if (shaderResourceIt == renderer->ResourceCache.Shaders.end() || !shaderResourceIt->second)
+                    const auto shaderResourceIt = renderer.Cache.Shaders.find(shaderProgramId);
+                    if (shaderResourceIt == renderer.Cache.Shaders.end() || !shaderResourceIt->second)
                     {
                         continue;
                     }
@@ -368,8 +362,8 @@ namespace Tbx
                                     continue;
                                 }
 
-                                const auto textureResourceIt = renderer->ResourceCache.Textures.find(texture->Id);
-                                if (textureResourceIt == renderer->ResourceCache.Textures.end() || !textureResourceIt->second)
+                                const auto textureResourceIt = renderer.Cache.Textures.find(texture->Id);
+                                if (textureResourceIt == renderer.Cache.Textures.end() || !textureResourceIt->second)
                                 {
                                     continue;
                                 }
@@ -391,8 +385,8 @@ namespace Tbx
                             continue;
                         }
 
-                        const auto meshResourceIt = renderer->ResourceCache.Meshes.find(entry.MeshBlock->Id);
-                        if (meshResourceIt == renderer->ResourceCache.Meshes.end() || !meshResourceIt->second)
+                        const auto meshResourceIt = renderer.Cache.Meshes.find(entry.MeshBlock->Id);
+                        if (meshResourceIt == renderer.Cache.Meshes.end() || !meshResourceIt->second)
                         {
                             continue;
                         }
@@ -416,7 +410,8 @@ namespace Tbx
                 }
             }
 
-            display.Context->SwapBuffers();
+            renderer.Backend->EndDraw(_clearColor);
+            display.Context->Present();
         }
 
         if (_eventBus)
@@ -488,15 +483,12 @@ namespace Tbx
     {
         for (auto& [api, renderer] : _renderers)
         {
-            if (renderer && renderer->ApiManager)
+            if (renderer.Backend)
             {
-                renderer->ApiManager->Shutdown();
+                renderer.Backend->Shutdown();
             }
 
-            if (renderer)
-            {
-                renderer->ResourceCache.Clear();
-            }
+            renderer.Cache.Clear();
         }
 
         for (auto& display : _openDisplays)
@@ -504,11 +496,13 @@ namespace Tbx
             display.Context = nullptr;
         }
 
-        Ref<GraphicsRenderer> renderer = nullptr;
-        if (!TryGetRenderer(_currApi, renderer) || !renderer || !renderer->ContextProvider)
+        GraphicsRenderer* renderer = nullptr;
+        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend || !renderer->ContextProvider)
         {
             return;
         }
+
+        renderer->Cache.Clear();
 
         for (auto& display : _openDisplays)
         {
@@ -517,41 +511,52 @@ namespace Tbx
                 continue;
             }
 
-            display.Context = renderer->ContextProvider->Provide(display.Surface, _currApi);
-            TBX_ASSERT(display.Context, "Rendering: Failed to recreate a graphics context for an open window.");
-            if (!display.Context)
+            auto context = renderer->ContextProvider->Provide(display.Surface);
+            TBX_ASSERT(context, "Rendering: Failed to recreate a graphics context for an open window.");
+            if (!context)
             {
                 continue;
             }
 
-            if (renderer->ApiManager)
-            {
-                renderer->ApiManager->Initialize(display.Context, _currApi);
-            }
+            renderer->Backend->Initialize(context);
+            display.Context = context;
         }
     }
 
-    void GraphicsPipeline::CompileShaders(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Shader>>& shaders)
+    void GraphicsPipeline::CompileShaders(const std::vector<Ref<Shader>>& shaders)
     {
-        if (!renderer || !renderer->ShaderCompiler || shaders.empty())
+        if (shaders.empty())
         {
             return;
         }
 
+        auto* renderer = FindRenderer(_activeGraphicsApi);
+        if (!renderer || !renderer->Backend)
+        {
+            return;
+        }
+
+        std::vector<Ref<Shader>> validShaders = {};
+        validShaders.reserve(shaders.size());
         for (const auto& shader : shaders)
         {
-            if (!shader)
+            if (shader)
             {
-                continue;
+                validShaders.push_back(shader);
             }
-
-            renderer->ShaderCompiler->Compile(shader, _currApi);
         }
+
+        if (validShaders.empty())
+        {
+            return;
+        }
+
+        renderer->Backend->CompileShaders(validShaders);
     }
 
-    void GraphicsPipeline::CacheShaders(const Ref<GraphicsRenderer>& renderer, const Material& material)
+    void GraphicsPipeline::CacheShaders(GraphicsRenderer& renderer, const Material& material)
     {
-        if (!renderer || !renderer->ResourceFactory || !material.ShaderProgram)
+        if (!renderer.Backend || !material.ShaderProgram)
         {
             return;
         }
@@ -562,7 +567,7 @@ namespace Tbx
             return;
         }
 
-        if (renderer->ResourceCache.Shaders.contains(shaderProgramId))
+        if (renderer.Cache.Shaders.contains(shaderProgramId))
         {
             return;
         }
@@ -582,7 +587,7 @@ namespace Tbx
             return;
         }
 
-        auto resource = renderer->ResourceFactory->Create(program);
+        auto resource = renderer.Backend->CreateResource(program);
         TBX_ASSERT(resource, "Rendering: Unable to cache shader program for active graphics api.");
         if (!resource)
         {
@@ -590,12 +595,12 @@ namespace Tbx
         }
 
         resource->RenderId = shaderProgramId;
-        renderer->ResourceCache.Shaders.emplace(shaderProgramId, resource);
+        renderer.Cache.Shaders.emplace(shaderProgramId, resource);
     }
 
-    void GraphicsPipeline::CacheTextures(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Texture>>& textures)
+    void GraphicsPipeline::CacheTextures(GraphicsRenderer& renderer, const std::vector<Ref<Texture>>& textures)
     {
-        if (!renderer || !renderer->ResourceFactory || textures.empty())
+        if (!renderer.Backend || textures.empty())
         {
             return;
         }
@@ -607,12 +612,12 @@ namespace Tbx
                 continue;
             }
 
-            if (renderer->ResourceCache.Textures.contains(texture->Id))
+            if (renderer.Cache.Textures.contains(texture->Id))
             {
                 continue;
             }
 
-            auto resource = renderer->ResourceFactory->Create(texture);
+            auto resource = renderer.Backend->CreateResource(texture);
             TBX_ASSERT(resource, "Rendering: Unable to cache textures for active graphics api.");
             if (!resource)
             {
@@ -620,13 +625,13 @@ namespace Tbx
             }
 
             resource->RenderId = texture->Id;
-            renderer->ResourceCache.Textures.emplace(texture->Id, resource);
+            renderer.Cache.Textures.emplace(texture->Id, resource);
         }
     }
 
-    void GraphicsPipeline::CacheMeshes(const Ref<GraphicsRenderer>& renderer, const std::vector<Ref<Mesh>>& meshes)
+    void GraphicsPipeline::CacheMeshes(GraphicsRenderer& renderer, const std::vector<Ref<Mesh>>& meshes)
     {
-        if (!renderer || !renderer->ResourceFactory || meshes.empty())
+        if (!renderer.Backend || meshes.empty())
         {
             return;
         }
@@ -638,12 +643,12 @@ namespace Tbx
                 continue;
             }
 
-            if (renderer->ResourceCache.Meshes.contains(mesh->Id))
+            if (renderer.Cache.Meshes.contains(mesh->Id))
             {
                 continue;
             }
 
-            auto resource = renderer->ResourceFactory->Create(mesh);
+            auto resource = renderer.Backend->CreateResource(mesh);
             TBX_ASSERT(resource, "Rendering: Unable to cache meshes for active graphics api.");
             if (!resource)
             {
@@ -651,18 +656,38 @@ namespace Tbx
             }
 
             resource->RenderId = mesh->Id;
-            renderer->ResourceCache.Meshes.emplace(mesh->Id, resource);
+            renderer.Cache.Meshes.emplace(mesh->Id, resource);
         }
     }
 
     void GraphicsPipeline::OnAppSettingsChanged(const AppSettingsChangedEvent& e)
     {
         const auto& newSettings = e.GetNewSettings();
-        _resolution = newSettings.Resolution;
         _clearColor = newSettings.ClearColor;
-        if (_currApi != newSettings.RenderingApi)
+        auto desiredApi = newSettings.RenderingApi;
+
+        const GraphicsRenderer* desiredRenderer = nullptr;
+        const bool rendererAvailable = TryGetRenderer(desiredApi, desiredRenderer) && desiredRenderer && desiredRenderer->Backend && desiredRenderer->ContextProvider;
+        if (!rendererAvailable)
         {
-            _currApi = newSettings.RenderingApi;
+            GraphicsApi fallbackApi = GraphicsApi::None;
+            for (const auto& [api, renderer] : _renderers)
+            {
+                if (!renderer.Backend || !renderer.ContextProvider)
+                {
+                    continue;
+                }
+
+                fallbackApi = api;
+                break;
+            }
+
+            desiredApi = fallbackApi;
+        }
+
+        if (_activeGraphicsApi != desiredApi)
+        {
+            _activeGraphicsApi = desiredApi;
             RecreateRenderersForCurrentApi();
         }
     }
@@ -676,8 +701,13 @@ namespace Tbx
             return;
         }
 
-        Ref<GraphicsRenderer> renderer = nullptr;
-        if (!TryGetRenderer(_currApi, renderer) || !renderer || !renderer->ContextProvider)
+        GraphicsRenderer* renderer = nullptr;
+        if (!TryGetRenderer(_activeGraphicsApi, renderer) || !renderer || !renderer->Backend)
+        {
+            return;
+        }
+
+        if (!renderer->ContextProvider)
         {
             return;
         }
@@ -687,17 +717,14 @@ namespace Tbx
             return display.Surface == newWindow;
         });
 
-        auto context = renderer->ContextProvider->Provide(newWindow, _currApi);
+        auto context = renderer->ContextProvider->Provide(newWindow);
         TBX_ASSERT(context, "Rendering: Failed to create a graphics context for the opened window.");
         if (!context)
         {
             return;
         }
 
-        if (renderer->ApiManager)
-        {
-            renderer->ApiManager->Initialize(context, _currApi);
-        }
+        renderer->Backend->Initialize(context);
 
         if (displayIt != _openDisplays.end())
         {
@@ -729,10 +756,11 @@ namespace Tbx
 
         if (_openDisplays.empty())
         {
-            Ref<GraphicsRenderer> renderer = nullptr;
-            if (TryGetRenderer(_currApi, renderer) && renderer && renderer->ApiManager)
+            GraphicsRenderer* renderer = nullptr;
+            if (TryGetRenderer(_activeGraphicsApi, renderer) && renderer && renderer->Backend)
             {
-                renderer->ApiManager->Shutdown();
+                renderer->Backend->Shutdown();
+                renderer->Cache.Clear();
             }
         }
     }
@@ -747,23 +775,40 @@ namespace Tbx
         RemoveStage(e.GetStage());
     }
 
-    bool GraphicsPipeline::TryGetRenderer(GraphicsApi api, Ref<GraphicsRenderer>& renderer)
+    bool GraphicsPipeline::TryGetRenderer(GraphicsApi api, GraphicsRenderer*& renderer)
     {
+        renderer = nullptr;
         if (api == GraphicsApi::None)
         {
-            renderer = nullptr;
             return false;
         }
 
         auto rendererIt = _renderers.find(api);
         if (rendererIt == _renderers.end())
         {
-            renderer = nullptr;
             return false;
         }
 
-        renderer = rendererIt->second;
-        return renderer != nullptr;
+        renderer = &rendererIt->second;
+        return true;
+    }
+
+    bool GraphicsPipeline::TryGetRenderer(GraphicsApi api, const GraphicsRenderer*& renderer) const
+    {
+        renderer = nullptr;
+        if (api == GraphicsApi::None)
+        {
+            return false;
+        }
+
+        auto rendererIt = _renderers.find(api);
+        if (rendererIt == _renderers.end())
+        {
+            return false;
+        }
+
+        renderer = &rendererIt->second;
+        return true;
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the compatibility gate in `App::Initialize` so graphics plugins are always passed to the rendering layer for validation

## Testing
- cmake -S . -B build *(fails: dependency and plugin submodules are missing from the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fd8ed1388327b41c674b91c206b5