### PR TITLE
Refine default render pass filtering

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsBackend.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsBackend.h
@@ -33,6 +33,11 @@ namespace Tbx
         virtual void SetContext(Ref<IGraphicsContext> context) = 0;
 
         /// <summary>
+        /// Enables or disables depth testing for subsequent draw calls.
+        /// </summary>
+        virtual void EnableDepthTesting(bool enabled) = 0;
+
+        /// <summary>
         /// Begins drawing to the active render target using the provided viewport.
         /// </summary>
         virtual void BeginDraw(const RgbaColor& clearColor, const Viewport& viewport) = 0;

--- a/Engine/Include/Tbx/Graphics/GraphicsManager.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsManager.h
@@ -1,10 +1,17 @@
 #pragma once
 #include "Tbx/Graphics/GraphicsPipeline.h"
+#include "Tbx/Events/EventBus.h"
+#include "Tbx/Events/EventListener.h"
+#include "Tbx/Events/StageEvents.h"
+#include "Tbx/Events/WindowEvents.h"
+#include "Tbx/Events/AppEvents.h"
+#include "Tbx/Events/RenderEvents.h"
+#include <vector>
+#include <unordered_map>
+#include <utility>
 
 namespace Tbx
 {
-    // TODO: Here we can add various helpers and ways to hook into the graphics pipeline
-    // Perhaps even host multiple pipelines for different things... like opaque passes, screen-space effects, etc.
     class GraphicsManager
     {
     public:
@@ -13,11 +20,39 @@ namespace Tbx
             GraphicsApi startingApi,
             const std::vector<Ref<IGraphicsBackend>>& backends,
             const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
-            Ref<EventBus> eventBus) : _pipeline(MakeExclusive<GraphicsPipeline>(startingApi, backends, contextProviders, eventBus)) { }
+            Ref<EventBus> eventBus);
 
-        void Update() { _pipeline->Update(); }
+        void Update();
+
+        void SetRenderPasses(std::vector<RenderPassDescriptor> passes);
+        const std::vector<RenderPassDescriptor>& GetRenderPasses() const;
+
+    private:
+        void InitializeRenderers(
+            const std::vector<Ref<IGraphicsBackend>>& backends,
+            const std::vector<Ref<IGraphicsContextProvider>>& contextProviders);
+        GraphicsRenderer* GetRenderer(GraphicsApi api);
+        void RecreateRenderersForCurrentApi();
+
+        void OnAppSettingsChanged(const AppSettingsChangedEvent& e);
+        void OnWindowOpened(const WindowOpenedEvent& e);
+        void OnWindowClosed(const WindowClosedEvent& e);
+        void OnStageOpened(const StageOpenedEvent& e);
+        void OnStageClosed(const StageClosedEvent& e);
+
+        static std::vector<RenderPassDescriptor> CreateDefaultRenderPasses();
 
     private:
         ExclusiveRef<GraphicsPipeline> _pipeline = nullptr;
+        Ref<EventBus> _eventBus = nullptr;
+        EventListener _eventListener = {};
+
+        std::vector<Ref<Stage>> _openStages = {};
+        std::vector<GraphicsDisplay> _openDisplays = {};
+        std::unordered_map<GraphicsApi, GraphicsRenderer> _renderers = {};
+
+        GraphicsApi _activeGraphicsApi = GraphicsApi::None;
+        VsyncMode _vsync = VsyncMode::Adaptive;
+        RgbaColor _clearColor = {};
     };
 }

--- a/Engine/Include/Tbx/Graphics/Material.h
+++ b/Engine/Include/Tbx/Graphics/Material.h
@@ -4,6 +4,7 @@
 #include "Tbx/Graphics/Texture.h"
 #include "Tbx/Memory/Refs.h"
 #include "Tbx/Ids/Uid.h"
+#include <string>
 #include <vector>
 
 namespace Tbx
@@ -40,6 +41,7 @@ namespace Tbx
 
         ShaderProgram ShaderProgram = {};
         std::vector<Ref<Texture>> Textures = { MakeRef<Texture>() }; // default to one small white texture
+        bool Transparent = false;
         Uid Id = Uid::Generate();
     };
 }

--- a/Engine/Include/Tbx/Graphics/RenderPass.h
+++ b/Engine/Include/Tbx/Graphics/RenderPass.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "Tbx/DllExport.h"
+#include <functional>
+#include <string>
+
+namespace Tbx
+{
+    struct Material;
+
+    using RenderPassFilter = std::function<bool(const Material&)>;
+
+    struct TBX_EXPORT RenderPassDescriptor
+    {
+        std::string Name = {};
+        bool DepthTestEnabled = true;
+        RenderPassFilter Filter = nullptr;
+    };
+}

--- a/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
@@ -1,0 +1,346 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Graphics/GraphicsManager.h"
+#include "Tbx/Debug/Asserts.h"
+#include "Tbx/Windowing/Window.h"
+#include <algorithm>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace Tbx
+{
+    GraphicsManager::GraphicsManager(
+        GraphicsApi startingApi,
+        const std::vector<Ref<IGraphicsBackend>>& backends,
+        const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
+        Ref<EventBus> eventBus)
+        : _eventBus(eventBus)
+        , _eventListener(eventBus)
+        , _activeGraphicsApi(startingApi)
+    {
+        TBX_ASSERT(!backends.empty(), "GraphicsManager: requires at least one graphics backend instance.");
+        TBX_ASSERT(_eventBus, "GraphicsManager: requires a valid event bus instance.");
+
+        InitializeRenderers(backends, contextProviders);
+        TBX_ASSERT(!_renderers.empty(), "GraphicsManager: No compatible renderer implementations were provided for the available graphics APIs.");
+
+        _pipeline = MakeExclusive<GraphicsPipeline>(CreateDefaultRenderPasses());
+        RecreateRenderersForCurrentApi();
+
+        _eventListener.Listen(this, &GraphicsManager::OnWindowOpened);
+        _eventListener.Listen(this, &GraphicsManager::OnWindowClosed);
+        _eventListener.Listen(this, &GraphicsManager::OnAppSettingsChanged);
+        _eventListener.Listen(this, &GraphicsManager::OnStageOpened);
+        _eventListener.Listen(this, &GraphicsManager::OnStageClosed);
+    }
+
+    void GraphicsManager::Update()
+    {
+        if (!_pipeline)
+        {
+            return;
+        }
+
+        auto* renderer = GetRenderer(_activeGraphicsApi);
+        if (!renderer)
+        {
+            return;
+        }
+
+        _pipeline->SetRenderer(renderer);
+
+        for (const auto& display : _openDisplays)
+        {
+            TBX_ASSERT(display.Surface && display.Context, "GraphicsManager: Display is missing a surface or context.");
+            _pipeline->Render(display, _openStages, _clearColor);
+        }
+
+        if (_eventBus)
+        {
+            _eventBus->Send(RenderedFrameEvent());
+        }
+    }
+
+    void GraphicsManager::SetRenderPasses(std::vector<RenderPassDescriptor> passes)
+    {
+        if (passes.empty())
+        {
+            TBX_ASSERT(false, "GraphicsManager: Render passes must not be empty.");
+            return;
+        }
+
+        _pipeline->SetRenderPasses(std::move(passes));
+    }
+
+    const std::vector<RenderPassDescriptor>& GraphicsManager::GetRenderPasses() const
+    {
+        return _pipeline->GetRenderPasses();
+    }
+
+    void GraphicsManager::InitializeRenderers(
+        const std::vector<Ref<IGraphicsBackend>>& backends,
+        const std::vector<Ref<IGraphicsContextProvider>>& contextProviders)
+    {
+        for (const auto& backend : backends)
+        {
+            if (!backend)
+            {
+                continue;
+            }
+
+            const auto api = backend->GetApi();
+            if (api == GraphicsApi::None)
+            {
+                continue;
+            }
+
+            auto& renderer = _renderers[api];
+            if (!renderer.Backend)
+            {
+                renderer.Backend = backend;
+            }
+        }
+
+        for (const auto& provider : contextProviders)
+        {
+            if (!provider)
+            {
+                continue;
+            }
+
+            const auto api = provider->GetApi();
+            if (api == GraphicsApi::None)
+            {
+                continue;
+            }
+
+            auto rendererIt = _renderers.find(api);
+            if (rendererIt == _renderers.end())
+            {
+                continue;
+            }
+
+            auto& renderer = rendererIt->second;
+            if (!renderer.ContextProvider)
+            {
+                renderer.ContextProvider = provider;
+            }
+        }
+
+        for (auto it = _renderers.begin(); it != _renderers.end();)
+        {
+            auto& renderer = it->second;
+            if (!renderer.Backend || !renderer.ContextProvider)
+            {
+                it = _renderers.erase(it);
+                continue;
+            }
+            ++it;
+        }
+    }
+
+    GraphicsRenderer* GraphicsManager::GetRenderer(GraphicsApi api)
+    {
+        if (api == GraphicsApi::None)
+        {
+            return nullptr;
+        }
+
+        auto rendererIt = _renderers.find(api);
+        if (rendererIt == _renderers.end())
+        {
+            return nullptr;
+        }
+
+        return &rendererIt->second;
+    }
+
+    void GraphicsManager::RecreateRenderersForCurrentApi()
+    {
+        for (auto& [api, renderer] : _renderers)
+        {
+            renderer.Cache.Clear();
+        }
+
+        for (auto& display : _openDisplays)
+        {
+            display.Context = nullptr;
+        }
+
+        auto* renderer = GetRenderer(_activeGraphicsApi);
+        if (!renderer)
+        {
+            _pipeline->SetRenderer(nullptr);
+            return;
+        }
+
+        _pipeline->SetRenderer(renderer);
+
+        for (auto& display : _openDisplays)
+        {
+            if (!display.Surface)
+            {
+                continue;
+            }
+
+            auto context = renderer->ContextProvider->Provide(display.Surface);
+            TBX_ASSERT(context, "GraphicsManager: Failed to recreate a graphics context for an open window.");
+            if (!context)
+            {
+                continue;
+            }
+
+            context->SetVsync(_vsync);
+            display.Context = context;
+        }
+    }
+
+    void GraphicsManager::OnAppSettingsChanged(const AppSettingsChangedEvent& e)
+    {
+        const auto& newSettings = e.GetNewSettings();
+        auto desiredApi = newSettings.RenderingApi;
+
+        if (_activeGraphicsApi != desiredApi)
+        {
+            _activeGraphicsApi = desiredApi;
+            RecreateRenderersForCurrentApi();
+        }
+
+        _vsync = newSettings.Vsync;
+        for (auto& display : _openDisplays)
+        {
+            if (display.Context)
+            {
+                display.Context->SetVsync(newSettings.Vsync);
+            }
+        }
+
+        _clearColor = newSettings.ClearColor;
+    }
+
+    void GraphicsManager::OnWindowOpened(const WindowOpenedEvent& e)
+    {
+        auto newWindow = e.GetWindow();
+        if (!newWindow)
+        {
+            TBX_ASSERT(newWindow, "GraphicsManager: Invalid window open event, ensure a valid window is passed!");
+            return;
+        }
+
+        auto* renderer = GetRenderer(_activeGraphicsApi);
+        if (!renderer)
+        {
+            return;
+        }
+
+        auto context = renderer->ContextProvider->Provide(newWindow);
+        TBX_ASSERT(context, "GraphicsManager: Failed to create a graphics context for the opened window.");
+        if (!context)
+        {
+            return;
+        }
+
+        context->SetVsync(_vsync);
+
+        GraphicsDisplay display = {};
+        display.Surface = newWindow;
+        display.Context = context;
+        _openDisplays.push_back(std::move(display));
+    }
+
+    void GraphicsManager::OnWindowClosed(const WindowClosedEvent& e)
+    {
+        auto closedWindow = e.GetWindow();
+        if (!closedWindow)
+        {
+            return;
+        }
+
+        auto displayIt = std::find_if(_openDisplays.begin(), _openDisplays.end(), [closedWindow](const GraphicsDisplay& display)
+        {
+            return display.Surface == closedWindow;
+        });
+
+        if (displayIt != _openDisplays.end())
+        {
+            _openDisplays.erase(displayIt);
+        }
+        else
+        {
+            TBX_ASSERT(false, "GraphicsManager: A renderer could not be found for the window that was closed!");
+        }
+    }
+
+    void GraphicsManager::OnStageOpened(const StageOpenedEvent& e)
+    {
+        auto stage = e.GetStage();
+        if (!stage)
+        {
+            return;
+        }
+
+        auto it = std::find(_openStages.begin(), _openStages.end(), stage);
+        if (it == _openStages.end())
+        {
+            _openStages.push_back(stage);
+        }
+    }
+
+    void GraphicsManager::OnStageClosed(const StageClosedEvent& e)
+    {
+        auto stage = e.GetStage();
+        if (!stage)
+        {
+            return;
+        }
+
+        auto it = std::find(_openStages.begin(), _openStages.end(), stage);
+        if (it != _openStages.end())
+        {
+            _openStages.erase(it);
+        }
+    }
+
+    std::vector<RenderPassDescriptor> GraphicsManager::CreateDefaultRenderPasses()
+    {
+        constexpr std::string_view OpaquePassName = "Opaque";
+        constexpr std::string_view TransparentPassName = "Transparent";
+
+        std::vector<RenderPassDescriptor> passes = {};
+        passes.reserve(2);
+
+        RenderPassDescriptor opaque = {};
+        opaque.Name = std::string(OpaquePassName);
+        opaque.DepthTestEnabled = true;
+        opaque.Filter = [](const Material& material)
+        {
+            const auto hasAlpha = std::any_of(
+                material.Textures.begin(),
+                material.Textures.end(),
+                [](const Ref<Texture>& texture)
+                {
+                    return texture && texture->Format == TextureFormat::RGBA;
+                });
+
+            return !hasAlpha;
+        };
+        passes.push_back(std::move(opaque));
+
+        RenderPassDescriptor transparent = {};
+        transparent.Name = std::string(TransparentPassName);
+        transparent.DepthTestEnabled = false;
+        transparent.Filter = [](const Material& material)
+        {
+            return std::any_of(
+                material.Textures.begin(),
+                material.Textures.end(),
+                [](const Ref<Texture>& texture)
+                {
+                    return texture && texture->Format == TextureFormat::RGBA;
+                });
+        };
+        passes.push_back(std::move(transparent));
+
+        return passes;
+    }
+}


### PR DESCRIPTION
## Summary
- stop exporting render pass name constants and default names to empty strings
- define opaque/transparent names when seeding default passes and classify materials by texture alpha formats

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e95f37ea2483278399a5e76dd4dff6