### PR TITLE
Smooth mouse look to reduce camera jitter

### DIFF
--- a/Examples/3dDemo/Runtime/Demo.h
+++ b/Examples/3dDemo/Runtime/Demo.h
@@ -5,6 +5,7 @@
 #include <Tbx/Stages/Stage.h>
 #include "Tbx/Memory/Refs.h"
 #include <Tbx/Graphics/Material.h>
+#include <Tbx/Math/Vectors.h>
 
 class Demo final : public Tbx::Runtime
 {
@@ -26,6 +27,7 @@ private:
 
     float _camPitch = 0.0f;
     float _camYaw = 0.0f;
+    Tbx::Vector2 _camLookVelocity = Tbx::Vector2::Zero;
 
     Tbx::Ref<Tbx::Material> _simpleTexturedMat = {};
     Tbx::WeakRef<Tbx::App> _app = {};


### PR DESCRIPTION
## Summary
- smooth mouse look input with a configurable rate to avoid jitter when moving and rotating
- keep accumulated yaw within [-180, 180] to prevent floating-point drift during long play sessions
- store transient look velocity on the demo runtime for reuse between frames

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68eabd0689648327b22bba153c4ce537