### PR TITLE
Move render pass depth handling into draw callbacks

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
@@ -71,10 +71,10 @@ namespace Tbx
         GraphicsPipeline() = default;
         explicit GraphicsPipeline(std::vector<RenderPass> passes);
         void Render(GraphicsRenderer& renderer, const GraphicsDisplay& display, const std::vector<Ref<Stage>>& stages, const RgbaColor& clearColor);
+        void RenderStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData);
 
     private:
         StageRenderData PrepareStageForRendering(GraphicsRenderer& renderer, const FullStageView& stageView, float aspectRatio);
-        void RenderStage(uint32 passIndex, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData);
         void RenderCameraView(const Tbx::RenderBucket& bucket, const Tbx::CameraData& camera, const Tbx::Ref<Tbx::ShaderProgramResource>& shaderResource, Tbx::GraphicsRenderer& renderer);
         void CacheShaders(GraphicsRenderer& renderer, const ShaderProgram& shaders);
         void CacheMaterial(GraphicsRenderer& renderer, const Material& shaders);

--- a/Engine/Include/Tbx/Graphics/RenderPass.h
+++ b/Engine/Include/Tbx/Graphics/RenderPass.h
@@ -6,13 +6,31 @@
 namespace Tbx
 {
     struct Material;
+    struct StageRenderData;
+    struct GraphicsRenderer;
+    class GraphicsPipeline;
+
+    struct RenderPass;
 
     using RenderPassFilter = std::function<bool(const Material&)>;
+    using RenderPassDraw = std::function<void(
+        GraphicsPipeline& pipeline,
+        const RenderPass& pass,
+        GraphicsRenderer& renderer,
+        StageRenderData& renderData)>;
 
     struct TBX_EXPORT RenderPass
     {
         std::string Name = {};
-        bool DepthTestEnabled = true;
         RenderPassFilter Filter = nullptr;
+        RenderPassDraw Draw = nullptr;
+
+        static void DefaultDraw(
+            GraphicsPipeline& pipeline,
+            const RenderPass& pass,
+            GraphicsRenderer& renderer,
+            StageRenderData& renderData);
+
+        static RenderPassDraw CreateDefaultDraw(bool enableDepthTesting);
     };
 }

--- a/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
@@ -252,7 +252,6 @@ namespace Tbx
 
         RenderPass opaque = {};
         opaque.Name = std::string(OpaquePassName);
-        opaque.DepthTestEnabled = true;
         opaque.Filter = [](const Material& material)
         {
             const auto hasAlpha = std::any_of(
@@ -265,11 +264,11 @@ namespace Tbx
 
             return !hasAlpha;
         };
+        opaque.Draw = RenderPass::CreateDefaultDraw(true);
         passes.push_back(std::move(opaque));
 
         RenderPass transparent = {};
         transparent.Name = std::string(TransparentPassName);
-        transparent.DepthTestEnabled = false;
         transparent.Filter = [](const Material& material)
         {
             return std::any_of(
@@ -280,6 +279,7 @@ namespace Tbx
                     return texture && texture->Format == TextureFormat::RGBA;
                 });
         };
+        transparent.Draw = RenderPass::CreateDefaultDraw(false);
         passes.push_back(std::move(transparent));
 
         return passes;

--- a/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
@@ -45,9 +45,16 @@ namespace Tbx
         {
             auto renderData = PrepareStageForRendering(renderer, FullStageView(stage->GetRoot()), aspectRatio);
 
-            for (uint32 passIndex = 0; passIndex < RenderPasses.size(); ++passIndex)
+            for (auto& pass : RenderPasses)
             {
-                RenderStage(passIndex, renderer, renderData);
+                if (pass.Draw)
+                {
+                    pass.Draw(*this, pass, renderer, renderData);
+                }
+                else
+                {
+                    RenderPass::DefaultDraw(*this, pass, renderer, renderData);
+                }
             }
         }
 
@@ -55,10 +62,10 @@ namespace Tbx
         display.Context->Present();
     }
 
-    void GraphicsPipeline::RenderStage(uint32 passIndex, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData)
+    void GraphicsPipeline::RenderStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData)
     {
-        const auto& pass = RenderPasses[passIndex];
-        renderer.Backend->EnableDepthTesting(pass.DepthTestEnabled);
+        const auto passIndex = static_cast<size_t>(&pass - RenderPasses.data());
+        TBX_ASSERT(passIndex < RenderPasses.size(), "GraphicsPipeline: Render pass is not part of the pipeline.");
 
         const auto& buckets = renderData.PassBuckets[passIndex];
         for (const auto& [shaderProgramId, bucket] : buckets)

--- a/Engine/Source/Tbx/Graphics/RenderPass.cpp
+++ b/Engine/Source/Tbx/Graphics/RenderPass.cpp
@@ -1,0 +1,31 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Graphics/RenderPass.h"
+#include "Tbx/Graphics/GraphicsPipeline.h"
+
+namespace Tbx
+{
+    void RenderPass::DefaultDraw(
+        GraphicsPipeline& pipeline,
+        const RenderPass& pass,
+        GraphicsRenderer& renderer,
+        StageRenderData& renderData)
+    {
+        renderer.Backend->EnableDepthTesting(true);
+        pipeline.RenderStage(pass, renderer, renderData);
+    }
+
+    RenderPassDraw RenderPass::CreateDefaultDraw(bool enableDepthTesting)
+    {
+        if (enableDepthTesting)
+        {
+            return RenderPass::DefaultDraw;
+        }
+
+        return [](GraphicsPipeline& pipeline, const RenderPass& pass, GraphicsRenderer& renderer, StageRenderData& renderData)
+        {
+            renderer.Backend->EnableDepthTesting(false);
+            pipeline.RenderStage(pass, renderer, renderData);
+            renderer.Backend->EnableDepthTesting(true);
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- remove the depth-test flag from render passes and add reusable default draw helpers
- update the default opaque and transparent passes to manage depth state through their draw callbacks
- route pipeline fallback rendering through the new default draw implementation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e9c525d0b483278ba82baa0a000d85