### PR TITLE
Optimize render pass lookup caching

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsManager.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsManager.h
@@ -21,7 +21,7 @@ namespace Tbx
             const std::vector<Ref<IGraphicsContextProvider>>& contextProviders,
             Ref<EventBus> eventBus);
 
-        void SetRenderPasses(const std::vector<RenderPass>& passes);
+        void SetRenderPasses(std::vector<RenderPass> passes);
         const std::vector<RenderPass>& GetRenderPasses() const;
         void Render();
 

--- a/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
@@ -70,6 +70,8 @@ namespace Tbx
     public:
         GraphicsPipeline() = default;
         explicit GraphicsPipeline(std::vector<RenderPass> passes);
+        void SetRenderPasses(std::vector<RenderPass> passes);
+        const std::vector<RenderPass>& GetRenderPasses() const { return _renderPasses; }
         void Process(GraphicsRenderer& renderer, const GraphicsDisplay& display, const std::vector<Ref<Stage>>& stages, const RgbaColor& clearColor);
         void DrawStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData);
 
@@ -82,8 +84,9 @@ namespace Tbx
         bool ShouldCull(const Ref<Toy>& toy, const Frustum& frustum);
         size_t ResolveRenderPassIndex(const Material& material) const;
 
-    public:
-        std::vector<RenderPass> RenderPasses = {};
+    private:
+        std::vector<RenderPass> _renderPasses = {};
+        mutable std::unordered_map<Uid, size_t> _materialPassCache = {};
     };
 }
 

--- a/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
@@ -50,7 +50,7 @@ namespace Tbx
         _eventBus->Send(RenderedFrameEvent());
     }
 
-    void GraphicsManager::SetRenderPasses(const std::vector<RenderPass>& passes)
+    void GraphicsManager::SetRenderPasses(std::vector<RenderPass> passes)
     {
         if (passes.empty())
         {
@@ -58,12 +58,12 @@ namespace Tbx
             return;
         }
 
-        _pipeline.RenderPasses = passes;
+        _pipeline.SetRenderPasses(std::move(passes));
     }
 
     const std::vector<RenderPass>& GraphicsManager::GetRenderPasses() const
     {
-        return _pipeline.RenderPasses;
+        return _pipeline.GetRenderPasses();
     }
 
     void GraphicsManager::InitializeRenderers(


### PR DESCRIPTION
## Summary
- add a render-pass cache inside `GraphicsPipeline` so filters are only evaluated when a material is first seen
- provide accessor methods on `GraphicsPipeline` and route `GraphicsManager` through them to keep caches in sync when passes change

## Testing
- cmake -S . -B build *(fails: dependency submodules such as glm and imgui are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb30030320832782529bebd7a2e8c8