### PR TITLE
Refine draw cache field names for GCC compliance

### DIFF
--- a/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
+++ b/Engine/Include/Tbx/Graphics/GraphicsPipeline.h
@@ -20,14 +20,21 @@ namespace Tbx
 
     struct CameraData
     {
-        Mat4x4 ViewProjection;
-        Frustum Frustum;
+        Mat4x4 ViewProj;
+        Frustum Frust;
     };
 
-    struct StageRenderData
+    struct ModelDrawData
+    {
+        const Material* Mat = nullptr;
+        const Mesh* Poly = nullptr;
+    };
+
+    struct StageDrawData
     {
         std::vector<RenderBuckets> PassBuckets = {};
         std::vector<CameraData> Cameras = {};
+        std::unordered_map<Uid, ModelDrawData> Drawables = {};
     };
 
     struct TBX_EXPORT GraphicsDisplay
@@ -71,15 +78,15 @@ namespace Tbx
         GraphicsPipeline() = default;
         explicit GraphicsPipeline(std::vector<RenderPass> passes);
         void Process(GraphicsRenderer& renderer, const GraphicsDisplay& display, const std::vector<Ref<Stage>>& stages, const RgbaColor& clearColor);
-        void DrawStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData);
+        void DrawStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageDrawData& renderData);
 
     private:
-        StageRenderData PrepareStageForDrawing(GraphicsRenderer& renderer, const FullStageView& stageView, float aspectRatio);
-        void RenderCameraView(const Tbx::RenderBucket& bucket, const Tbx::CameraData& camera, const Tbx::Ref<Tbx::ShaderProgramResource>& shaderResource, Tbx::GraphicsRenderer& renderer);
+        StageDrawData PrepareStageForDrawing(GraphicsRenderer& renderer, const FullStageView& stageView, float aspectRatio);
+        void RenderCameraView(const Tbx::RenderBucket& bucket, const Tbx::CameraData& camera, const Tbx::Ref<Tbx::ShaderProgramResource>& shaderResource, Tbx::GraphicsRenderer& renderer, const StageDrawData& renderData);
         void CacheShaders(GraphicsRenderer& renderer, const ShaderProgram& shaders);
         void CacheMaterial(GraphicsRenderer& renderer, const Material& shaders);
         void CacheMesh(GraphicsRenderer& renderer, const Mesh& mesh);
-        bool ShouldCull(const Ref<Toy>& toy, const Frustum& frustum);
+        bool ShouldCull(const Ref<Toy>& toy, const Frustum& frustum, const StageDrawData& renderData);
         size_t ResolveRenderPassIndex(const Material& material) const;
 
     public:

--- a/Engine/Include/Tbx/Graphics/Material.h
+++ b/Engine/Include/Tbx/Graphics/Material.h
@@ -31,17 +31,26 @@ namespace Tbx
     {
         Material() = default;
         Material(std::vector<Ref<Shader>> shaders)
-            : ShaderProgram(shaders) {}
+            : Shaders(ShaderProgram(shaders)) {}
         Material(std::vector<Ref<Shader>> shaders, Ref<Texture> texture)
-            : ShaderProgram(shaders)
+            : Shaders(ShaderProgram(shaders))
             , Textures({texture}) {}
         Material(std::vector<Ref<Shader>> shaders, std::vector<Ref<Texture>> textures)
-            : ShaderProgram(shaders)
+            : Shaders(ShaderProgram(shaders))
             , Textures(textures) {}
 
-        ShaderProgram ShaderProgram = {};
+        ShaderProgram Shaders = {};
         std::vector<Ref<Texture>> Textures = { MakeRef<Texture>() }; // default to one small white texture
         bool Transparent = false;
         Uid Id = Uid::Generate();
+    };
+
+    /// <summary>
+    /// References a shared material by identifier.
+    /// </summary>
+    struct TBX_EXPORT MaterialInstance
+    {
+        Uid MaterialId = Uid::Invalid;
+        Uid InstanceId = Uid::Generate();
     };
 }

--- a/Engine/Include/Tbx/Graphics/Model.h
+++ b/Engine/Include/Tbx/Graphics/Model.h
@@ -10,7 +10,17 @@ namespace Tbx
     /// </summary>
     struct TBX_EXPORT Model
     {
-        Mesh Mesh;
-        Material Material;
+        Mesh Poly;
+        Material Mat;
+        Uid Id = Uid::Generate();
+    };
+
+    /// <summary>
+    /// References a shared model by identifier.
+    /// </summary>
+    struct TBX_EXPORT ModelInstance
+    {
+        Uid ModelId = Uid::Invalid;
+        Uid InstanceId = Uid::Generate();
     };
 }

--- a/Engine/Include/Tbx/Graphics/RenderPass.h
+++ b/Engine/Include/Tbx/Graphics/RenderPass.h
@@ -6,7 +6,7 @@
 namespace Tbx
 {
     struct Material;
-    struct StageRenderData;
+    struct StageDrawData;
     struct GraphicsRenderer;
     class GraphicsPipeline;
 
@@ -16,7 +16,7 @@ namespace Tbx
     using RenderPassDraw = std::function<void(
         GraphicsPipeline& pipeline,
         GraphicsRenderer& renderer,
-        StageRenderData& renderData,
+        StageDrawData& renderData,
         const RenderPass& pass)>;
 
     struct TBX_EXPORT RenderPass

--- a/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsManager.cpp
@@ -264,7 +264,7 @@ namespace Tbx
 
             return !hasAlpha;
         };
-        opaque.Draw = [](GraphicsPipeline& pipeline, GraphicsRenderer& renderer, StageRenderData& renderData, const RenderPass& pass)
+        opaque.Draw = [](GraphicsPipeline& pipeline, GraphicsRenderer& renderer, StageDrawData& renderData, const RenderPass& pass)
         {
             pipeline.DrawStage(pass, renderer, renderData);
         };
@@ -282,7 +282,7 @@ namespace Tbx
                     return texture && texture->Format == TextureFormat::RGBA;
                 });
         };
-        transparent.Draw = [](GraphicsPipeline& pipeline,  GraphicsRenderer& renderer, StageRenderData& renderData, const RenderPass& pass)
+        transparent.Draw = [](GraphicsPipeline& pipeline,  GraphicsRenderer& renderer, StageDrawData& renderData, const RenderPass& pass)
         {
             renderer.Backend->EnableDepthTesting(false);
             pipeline.DrawStage(pass, renderer, renderData);

--- a/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
+++ b/Engine/Source/Tbx/Graphics/GraphicsPipeline.cpp
@@ -62,7 +62,7 @@ namespace Tbx
         renderer.Backend->EndDraw();
     }
 
-    void GraphicsPipeline::DrawStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageRenderData& renderData)
+    void GraphicsPipeline::DrawStage(const RenderPass& pass, Tbx::GraphicsRenderer& renderer, Tbx::StageDrawData& renderData)
     {
         const auto passIndex = static_cast<size_t>(&pass - RenderPasses.data());
         TBX_ASSERT(passIndex < RenderPasses.size(), "GraphicsPipeline: Render pass is not part of the pipeline.");
@@ -83,19 +83,19 @@ namespace Tbx
             {
                 ShaderUniform viewProjectionUniform = {};
                 viewProjectionUniform.Name = VIEW_PROJECTION_UNIFORM_NAME;
-                viewProjectionUniform.Data = camera.ViewProjection;
+                viewProjectionUniform.Data = camera.ViewProj;
                 shaderResource->Upload(viewProjectionUniform);
 
-                RenderCameraView(bucket, camera, shaderResource, renderer);
+                RenderCameraView(bucket, camera, shaderResource, renderer, renderData);
             }
         }
     }
 
-    void GraphicsPipeline::RenderCameraView(const Tbx::RenderBucket& bucket, const Tbx::CameraData& camera, const Tbx::Ref<Tbx::ShaderProgramResource>& shaderResource, Tbx::GraphicsRenderer& renderer)
+    void GraphicsPipeline::RenderCameraView(const Tbx::RenderBucket& bucket, const Tbx::CameraData& camera, const Tbx::Ref<Tbx::ShaderProgramResource>& shaderResource, Tbx::GraphicsRenderer& renderer, const StageDrawData& renderData)
     {
         for (const auto& entityPtr : bucket)
         {
-            if (ShouldCull(entityPtr, camera.Frustum))
+            if (ShouldCull(entityPtr, camera.Frust, renderData))
             {
                 continue;
             }
@@ -114,12 +114,23 @@ namespace Tbx
             transformUniform.Data = transformMatrix;
             shaderResource->Upload(transformUniform);
 
-            std::vector<UseGraphicsResourceScope> textureScopes = {};
-            const auto material = entity.Get<Material>();
-            textureScopes.reserve(material->Textures.size());
-            for (size_t textureIndex = 0; textureIndex < material->Textures.size(); ++textureIndex)
+            const auto drawDataIt = renderData.Drawables.find(entity.Handle.Id);
+            if (drawDataIt == renderData.Drawables.end())
             {
-                const auto& texture = material->Textures[textureIndex];
+                continue;
+            }
+
+            const auto& drawData = drawDataIt->second;
+            if (!drawData.Mat || !drawData.Poly)
+            {
+                continue;
+            }
+
+            std::vector<UseGraphicsResourceScope> textureScopes = {};
+            textureScopes.reserve(drawData.Mat->Textures.size());
+            for (size_t textureIndex = 0; textureIndex < drawData.Mat->Textures.size(); ++textureIndex)
+            {
+                const auto& texture = drawData.Mat->Textures[textureIndex];
                 if (!texture)
                 {
                     continue;
@@ -136,8 +147,7 @@ namespace Tbx
                 textureScopes.emplace_back(textureResource);
             }
 
-            const auto mesh = entity.Get<Mesh>();
-            const auto meshResourceIt = renderer.Cache.Meshes.find(mesh->Id);
+            const auto meshResourceIt = renderer.Cache.Meshes.find(drawData.Poly->Id);
             if (meshResourceIt == renderer.Cache.Meshes.end() || !meshResourceIt->second)
             {
                 continue;
@@ -148,16 +158,56 @@ namespace Tbx
         }
     }
 
-    StageRenderData GraphicsPipeline::PrepareStageForDrawing(
+    StageDrawData GraphicsPipeline::PrepareStageForDrawing(
         GraphicsRenderer& renderer,
         const FullStageView& stageView,
         float aspectRatio)
     {
-        StageRenderData renderData = {};
+        StageDrawData renderData = {};
         renderData.PassBuckets.resize(RenderPasses.size());
+
+        std::unordered_map<Uid, const Mesh*> meshRegistry = {};
+        std::unordered_map<Uid, const Material*> materialRegistry = {};
+        std::unordered_map<Uid, const Model*> modelRegistry = {};
+
+        meshRegistry.emplace(Mesh::Quad.Id, &Mesh::Quad);
+        meshRegistry.emplace(Mesh::Triangle.Id, &Mesh::Triangle);
 
         for (const auto& toy : stageView)
         {
+            if (!toy)
+            {
+                continue;
+            }
+
+            Ref<Mesh> meshRef;
+            if (toy->TryGet(meshRef) && meshRef)
+            {
+                meshRegistry[meshRef->Id] = meshRef.get();
+            }
+
+            Ref<Material> materialRef;
+            if (toy->TryGet(materialRef) && materialRef)
+            {
+                materialRegistry[materialRef->Id] = materialRef.get();
+            }
+
+            Ref<Model> modelRef;
+            if (toy->TryGet(modelRef) && modelRef)
+            {
+                modelRegistry[modelRef->Id] = modelRef.get();
+                meshRegistry[modelRef->Poly.Id] = &modelRef->Poly;
+                materialRegistry[modelRef->Mat.Id] = &modelRef->Mat;
+            }
+        }
+
+        for (const auto& toy : stageView)
+        {
+            if (!toy)
+            {
+                continue;
+            }
+
             if (toy->Has<Camera>())
             {
                 auto camera = toy->Get<Camera>();
@@ -180,36 +230,104 @@ namespace Tbx
                     Camera::CalculateViewProjectionMatrix(camPos, camRot, camera->GetProjectionMatrix()),
                     Camera::CalculateFrustum(camPos, camRot, camera->GetProjectionMatrix()));
             }
-            if (toy->Has<Model>() && toy->Has<Material>() ||
-                toy->Has<Model>() && toy->Has<Mesh>())
+            const bool hasModel = toy->Has<Model>();
+            const bool hasModelInstance = toy->Has<ModelInstance>();
+            const bool hasMesh = toy->Has<Mesh>();
+            const bool hasMeshInstance = toy->Has<MeshInstance>();
+            const bool hasMaterial = toy->Has<Material>();
+            const bool hasMaterialInstance = toy->Has<MaterialInstance>();
+
+            if ((hasModel && (hasModelInstance || hasMesh || hasMeshInstance || hasMaterial || hasMaterialInstance)) ||
+                (hasModelInstance && (hasMesh || hasMeshInstance || hasMaterial || hasMaterialInstance)) ||
+                (hasMesh && hasMeshInstance) ||
+                (hasMaterial && hasMaterialInstance))
             {
-                TBX_ASSERT(false, "GraphicsPipeline: You can have a mesh and material, or a model. Not both!");
+                TBX_ASSERT(false, "GraphicsPipeline: Conflicting model, mesh, or material blocks on toy.");
+                continue;
             }
-            else if (toy->Has<Model>())
+
+            const Model* resolvedModel = nullptr;
+            if (hasModel)
             {
                 const auto model = toy->Get<Model>();
-                CacheMaterial(renderer, model->Material);
-                CacheMesh(renderer, model->Mesh);
-                const size_t passIndex = ResolveRenderPassIndex(model->Material);
-                auto& passBuckets = renderData.PassBuckets[passIndex];
-                passBuckets[model->Material.ShaderProgram.Id].push_back(toy);
+                resolvedModel = model.get();
             }
-            else if (toy->Has<Material>() && toy->Has<Mesh>())
+            else if (hasModelInstance)
+            {
+                Ref<ModelInstance> modelInstance;
+                if (toy->TryGet(modelInstance) && modelInstance)
+                {
+                    auto modelIt = modelRegistry.find(modelInstance->ModelId);
+                    if (modelIt != modelRegistry.end())
+                    {
+                        resolvedModel = modelIt->second;
+                    }
+                }
+            }
+
+            const Material* resolvedMaterial = nullptr;
+            if (resolvedModel)
+            {
+                resolvedMaterial = &resolvedModel->Mat;
+            }
+            else if (hasMaterial)
+            {
+                const auto material = toy->Get<Material>();
+                resolvedMaterial = material.get();
+            }
+            else if (hasMaterialInstance)
+            {
+                Ref<MaterialInstance> materialInstance;
+                if (toy->TryGet(materialInstance) && materialInstance)
+                {
+                    auto materialIt = materialRegistry.find(materialInstance->MaterialId);
+                    if (materialIt != materialRegistry.end())
+                    {
+                        resolvedMaterial = materialIt->second;
+                    }
+                }
+            }
+
+            const Mesh* resolvedMesh = nullptr;
+            if (resolvedModel)
+            {
+                resolvedMesh = &resolvedModel->Poly;
+            }
+            else if (hasMesh)
             {
                 const auto mesh = toy->Get<Mesh>();
-                const auto material = toy->Get<Material>();
-                CacheMaterial(renderer, *material);
-                CacheMesh(renderer, *mesh);
-                const size_t passIndex = ResolveRenderPassIndex(*material);
-                auto& passBuckets = renderData.PassBuckets[passIndex];
-                passBuckets[material->ShaderProgram.Id].push_back(toy);
+                resolvedMesh = mesh.get();
             }
+            else if (hasMeshInstance)
+            {
+                Ref<MeshInstance> meshInstance;
+                if (toy->TryGet(meshInstance) && meshInstance)
+                {
+                    auto meshIt = meshRegistry.find(meshInstance->MeshId);
+                    if (meshIt != meshRegistry.end())
+                    {
+                        resolvedMesh = meshIt->second;
+                    }
+                }
+            }
+
+            if (!resolvedMaterial || !resolvedMesh)
+            {
+                continue;
+            }
+
+            CacheMaterial(renderer, *resolvedMaterial);
+            CacheMesh(renderer, *resolvedMesh);
+            const size_t passIndex = ResolveRenderPassIndex(*resolvedMaterial);
+            auto& passBuckets = renderData.PassBuckets[passIndex];
+            passBuckets[resolvedMaterial->Shaders.Id].push_back(toy);
+            renderData.Drawables[toy->Handle.Id] = { resolvedMaterial, resolvedMesh };
         }
 
         return renderData;
     }
 
-    bool GraphicsPipeline::ShouldCull(const Ref<Toy>& toy, const Frustum& frustum)
+    bool GraphicsPipeline::ShouldCull(const Ref<Toy>& toy, const Frustum& frustum, const StageDrawData& renderData)
     {
         if (!toy)
         {
@@ -221,8 +339,10 @@ namespace Tbx
             return false;
         }
 
-        if (!toy->Has<Mesh>() ||
-            !toy->Has<Material>())
+        const auto drawDataIt = renderData.Drawables.find(toy->Handle.Id);
+        if (drawDataIt == renderData.Drawables.end() ||
+            !drawDataIt->second.Mat ||
+            !drawDataIt->second.Poly)
         {
             return true;
         }
@@ -282,7 +402,7 @@ namespace Tbx
 
     void GraphicsPipeline::CacheMaterial(GraphicsRenderer& renderer, const Material& material)
     {
-        CacheShaders(renderer, material.ShaderProgram);
+        CacheShaders(renderer, material.Shaders);
 
         auto& cache = renderer.Cache;
 


### PR DESCRIPTION
## Summary
- rename the camera data view-projection member to ViewProj per review feedback
- rename model draw cache members to Mat and Poly so GCC no longer emits -Wchanges-meaning warnings

## Testing
- cmake -S . -B build *(fails: dependency submodules are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb407d05848327b2a389ec4dd73af2