### PR TITLE
Refine plugin library manager state handling

### DIFF
--- a/Engine/Include/Tbx/Events/PluginEvents.h
+++ b/Engine/Include/Tbx/Events/PluginEvents.h
@@ -9,18 +9,20 @@ namespace Tbx
 
     struct TBX_EXPORT PluginLoadedEvent final : public Event
     {
-        PluginLoadedEvent(WeakRef<Plugin> plugin)
-            : Plugin(plugin) {}
+        PluginLoadedEvent(const WeakRef<Plugin>& plugin, const PluginMeta& meta)
+            : Plugin(plugin), Meta(meta) {}
 
-        const WeakRef<Plugin> Plugin = {};
+        WeakRef<Plugin> Plugin = {};
+        PluginMeta Meta = {};
     };
 
     struct TBX_EXPORT PluginUnloadedEvent final : public Event
     {
-        PluginUnloadedEvent(WeakRef<Plugin> plugin)
-            : Plugin(plugin) {}
+        PluginUnloadedEvent(const WeakRef<Plugin>& plugin, const PluginMeta& meta)
+            : Plugin(plugin), Meta(meta) {}
 
-        const WeakRef<Plugin> Plugin = {};
+        WeakRef<Plugin> Plugin = {};
+        PluginMeta Meta = {};
     };
 
     struct TBX_EXPORT PluginDestroyedEvent final : public Event

--- a/Engine/Include/Tbx/Plugins/Plugin.h
+++ b/Engine/Include/Tbx/Plugins/Plugin.h
@@ -18,9 +18,9 @@ namespace Tbx
 
     struct LoadedPlugin
     {
-        Ref<Plugin> Instance;
-        ExclusiveRef<SharedLibrary> Library;
-        PluginMeta Meta;
+        WeakRef<Plugin> Instance = {};
+        ExclusiveRef<SharedLibrary> Library = nullptr;
+        PluginMeta Meta = {};
     };
 
     class TBX_EXPORT IProductOfPluginFactory

--- a/Engine/Include/Tbx/Plugins/PluginLibraryManager.h
+++ b/Engine/Include/Tbx/Plugins/PluginLibraryManager.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "Tbx/DllExport.h"
+#include "Tbx/Plugins/Plugin.h"
+#include "Tbx/Memory/Refs.h"
+
+namespace Tbx
+{
+    class SharedLibrary;
+    struct PluginDestroyedEvent;
+
+    class TBX_EXPORT PluginLibraryManager
+    {
+    public:
+        PluginLibraryManager() = delete;
+
+        static void Register(const Ref<Plugin>& plugin, ExclusiveRef<SharedLibrary>&& library, const PluginMeta& meta);
+        static void Unregister(const Plugin* plugin);
+    private:
+        static void EnsureInitialized();
+        static void HandleDestroyed(PluginDestroyedEvent& event);
+    };
+}

--- a/Engine/Include/Tbx/Plugins/PluginLoader.h
+++ b/Engine/Include/Tbx/Plugins/PluginLoader.h
@@ -19,15 +19,15 @@ namespace Tbx
             Ref<EventBus> eventBus);
 
         /// <summary>
-        /// Produces the loaded plugin collection, transferring ownership to the caller.
+        /// Produces the loaded plugin collection.
         /// </summary>
-        Queryable<LoadedPlugin> Results();
+        Queryable<Ref<Plugin>> Results();
 
     private:
         void LoadPlugins(const std::vector<PluginMeta>& pluginMetas);
 
     private:
-        std::vector<LoadedPlugin> _plugins;
+        std::vector<Ref<Plugin>> _plugins;
         Ref<EventBus> _eventBus = nullptr;
     };
 }

--- a/Engine/Source/Tbx/Plugins/PluginLibraryManager.cpp
+++ b/Engine/Source/Tbx/Plugins/PluginLibraryManager.cpp
@@ -1,0 +1,160 @@
+#include "Tbx/PCH.h"
+#include "Tbx/Plugins/PluginLibraryManager.h"
+#include "Tbx/Debug/Asserts.h"
+#include "Tbx/Debug/Tracers.h"
+#include "Tbx/Events/EventBus.h"
+#include "Tbx/Events/EventListener.h"
+#include "Tbx/Events/EventCarrier.h"
+#include "Tbx/Events/PluginEvents.h"
+#include <mutex>
+#include <unordered_map>
+
+namespace Tbx
+{
+    struct PluginLibraryState
+    {
+        std::unordered_map<const Plugin*, LoadedPlugin> Plugins = {};
+        std::mutex Mutex = {};
+        EventListener Listener = {};
+        bool Initialized = false;
+    };
+
+    static PluginLibraryState State = {};
+
+    static bool RemovePlugin(const Plugin* plugin, LoadedPlugin& unloaded)
+    {
+        if (!plugin)
+        {
+            return false;
+        }
+
+        std::scoped_lock lock(State.Mutex);
+        auto it = State.Plugins.find(plugin);
+        if (it == State.Plugins.end())
+        {
+            return false;
+        }
+
+        unloaded = std::move(it->second);
+        State.Plugins.erase(it);
+        return true;
+    }
+
+    void PluginLibraryManager::Register(const Ref<Plugin>& plugin, ExclusiveRef<SharedLibrary>&& library, const PluginMeta& meta)
+    {
+        EnsureInitialized();
+
+        TBX_ASSERT(plugin, "PluginLibraryManager: Cannot register a null plugin instance.");
+        if (!plugin)
+        {
+            return;
+        }
+
+        TBX_ASSERT(library != nullptr, "PluginLibraryManager: Cannot register a plugin without its library.");
+        if (!library)
+        {
+            return;
+        }
+
+        const auto pluginPtr = plugin.get();
+        auto weakPlugin = WeakRef<Plugin>(plugin);
+        auto shouldDispatchLoaded = false;
+
+        {
+            std::scoped_lock lock(State.Mutex);
+            auto [it, inserted] = State.Plugins.try_emplace(pluginPtr);
+            if (!inserted)
+            {
+                TBX_TRACE_WARNING("PluginLibraryManager: Plugin '{}' registered multiple times; refreshing metadata.", meta.Name);
+            }
+
+            it->second.Instance = weakPlugin;
+            it->second.Meta = meta;
+            it->second.Library = std::move(library);
+            shouldDispatchLoaded = inserted;
+        }
+
+        auto bus = EventBus::Global;
+        if (!bus)
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Missing event bus during registration of '{}'.", meta.Name);
+            return;
+        }
+
+        if (shouldDispatchLoaded)
+        {
+            EventCarrier(bus).Send(PluginLoadedEvent(weakPlugin, meta));
+        }
+        else
+        {
+            TBX_TRACE_VERBOSE("PluginLibraryManager: Duplicate registration detected for '{}'.", meta.Name);
+        }
+    }
+
+    void PluginLibraryManager::EnsureInitialized()
+    {
+        if (State.Initialized)
+        {
+            return;
+        }
+
+        auto bus = EventBus::Global;
+        TBX_ASSERT(bus, "PluginLibraryManager: Missing global event bus.");
+        if (!bus)
+        {
+            return;
+        }
+
+        State.Listener.Bind(bus);
+        State.Listener.Listen<PluginDestroyedEvent>(&PluginLibraryManager::HandleDestroyed);
+
+        State.Initialized = true;
+    }
+
+    void PluginLibraryManager::HandleDestroyed(PluginDestroyedEvent& event)
+    {
+        LoadedPlugin unloaded = {};
+        if (!RemovePlugin(event.Plugin, unloaded))
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Received destruction for untracked plugin at {}.", static_cast<const void*>(event.Plugin));
+            return;
+        }
+
+        auto bus = EventBus::Global;
+        if (!bus)
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Missing event bus while unloading plugin '{}'.", unloaded.Meta.Name);
+            return;
+        }
+
+        EventCarrier(bus).Send(PluginUnloadedEvent(unloaded.Instance, unloaded.Meta));
+    }
+
+    void PluginLibraryManager::Unregister(const Plugin* plugin)
+    {
+        EnsureInitialized();
+        if (!plugin)
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Ignoring manual unregister for null plugin pointer.");
+            return;
+        }
+
+        LoadedPlugin unloaded = {};
+        if (!RemovePlugin(plugin, unloaded))
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Manual unregister requested for untracked plugin at {}.", static_cast<const void*>(plugin));
+            return;
+        }
+
+        TBX_TRACE_WARNING("PluginLibraryManager: Manually unregistering plugin '{}'; ensure no dangling references remain.", unloaded.Meta.Name);
+
+        auto bus = EventBus::Global;
+        if (!bus)
+        {
+            TBX_TRACE_WARNING("PluginLibraryManager: Missing event bus while manually unloading plugin '{}'.", unloaded.Meta.Name);
+            return;
+        }
+
+        EventCarrier(bus).Send(PluginUnloadedEvent(unloaded.Instance, unloaded.Meta));
+    }
+}

--- a/Engine/Source/Tbx/Plugins/PluginLoader.cpp
+++ b/Engine/Source/Tbx/Plugins/PluginLoader.cpp
@@ -4,6 +4,7 @@
 #include "Tbx/Events/PluginEvents.h"
 #include "Tbx/Debug/Tracers.h"
 #include "Tbx/Memory/Refs.h"
+#include "Tbx/Plugins/PluginLibraryManager.h"
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -22,7 +23,7 @@ namespace Tbx
         const PluginMeta& info,
         Ref<EventBus> eventBus,
         std::unordered_set<std::string>& loadedNames,
-        std::vector<LoadedPlugin>& outLoaded)
+        std::vector<Ref<Plugin>>& outLoaded)
     {
         auto library = MakeExclusive<SharedLibrary>(info.Path);
         if (!library->IsValid())
@@ -75,9 +76,8 @@ namespace Tbx
 
         ReportPluginInfo(info);
         loadedNames.insert(pluginName);
-        outLoaded.emplace_back(plugin, std::move(library), info);
-
-        PluginServer.Register(plugin);
+        PluginLibraryManager::Register(plugin, std::move(library), info);
+        outLoaded.push_back(plugin);
 
         return true;
     }
@@ -90,9 +90,9 @@ namespace Tbx
         LoadPlugins(pluginMetas);
     }
 
-    Queryable<LoadedPlugin> PluginLoader::Results()
+    Queryable<Ref<Plugin>> PluginLoader::Results()
     {
-        return Queryable<LoadedPlugin>(_plugins);
+        return Queryable<Ref<Plugin>>(_plugins);
     }
 
     void PluginLoader::LoadPlugins(const std::vector<PluginMeta>& pluginMetas)

--- a/Launcher/Source/Tbx/Launcher/Launcher.cpp
+++ b/Launcher/Source/Tbx/Launcher/Launcher.cpp
@@ -10,19 +10,19 @@ namespace Tbx::Launcher
     static App CreateApp(const AppConfig& config)
     {
         // Load plugins and runtimes
-        Queryable<LoadedPlugin> loadedPlugins;
+        Queryable<Ref<Plugin>> loadedPlugins;
         {
             auto pluginMetas = PluginFinder(FileSystem::GetPluginDirectory(), config.Plugins).Result();
             loadedPlugins = PluginLoader(pluginMetas, EventBus::Global).Results();
         }
 
         // Get runtimes and separate them from the rest of the plugins
-        auto runtimes = loadedPlugins
-            .Select([](const LoadedPlugin& lp) { return lp.Instance; })
-            .OfType<Runtime>();
+        auto runtimes = loadedPlugins.OfType<Runtime>();
         auto plugins = loadedPlugins
-            .Select([](const LoadedPlugin& lp) { return lp.Instance; })
-            .Where([&](const Ref<Plugin>& p) { return !runtimes.Any([&p](const Ref<Runtime>& r) { return r.get() == p.get(); }); });
+            .Where([&](const Ref<Plugin>& plugin)
+            {
+                return !runtimes.Any([&](const Ref<Runtime>& runtime) { return runtime.get() == plugin.get(); });
+            });
 
         return App(config.Name, config.Settings, plugins, runtimes, EventBus::Global);
     }


### PR DESCRIPTION
## Summary
- move the plugin library manager state into namespace scope with a shared removal helper to satisfy style guidance
- adjust plugin loaded/unloaded event constructors to use the preferred initializer formatting
- add a manual unregister entry point that warns callers and avoid re-emitting load events on duplicate registrations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f3e99ee7d88327bdb6b09149d8b426