### PR TITLE
Refine asset wrapper accessors

### DIFF
--- a/Engine/Include/Tbx/Assets/AssetLoaders.h
+++ b/Engine/Include/Tbx/Assets/AssetLoaders.h
@@ -7,78 +7,155 @@
 #include "Tbx/Graphics/Text.h"
 #include "Tbx/Memory/Refs.h"
 #include <filesystem>
-#include <any>
+#include <typeindex>
+#include <utility>
 
 
 namespace Tbx
 {
-    using Asset = std::any;
+    class Asset
+    {
+    public:
+        Asset()
+            : _type(typeid(void))
+            , _data(nullptr)
+        {
+        }
+
+        Asset(std::type_index type, Ref<void> data)
+            : _type(type)
+            , _data(std::move(data))
+        {
+        }
+
+        template <typename TAsset>
+        Asset(const Ref<TAsset>& data)
+            : _type(typeid(TAsset))
+            , _data(std::static_pointer_cast<void>(data))
+        {
+        }
+
+        template <typename TAsset>
+        Ref<TAsset> GetData() const
+        {
+            if (_data == nullptr || _type != std::type_index(typeid(TAsset)))
+            {
+                return nullptr;
+            }
+
+            return std::static_pointer_cast<TAsset>(_data);
+        }
+
+        std::type_index GetType() const
+        {
+            return _type;
+        }
+
+        bool IsValid() const
+        {
+            return _data != nullptr;
+        }
+
+    private:
+        std::type_index _type;
+        Ref<void> _data;
+    };
 
     class TBX_EXPORT IAssetLoader
     {
     public:
         virtual ~IAssetLoader();
-        virtual bool CanLoad(const std::filesystem::path& filepath) const = 0;
+        virtual bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const = 0;
         virtual Asset Load(const std::filesystem::path& filepath) = 0;
     };
 
     class TBX_EXPORT ITextureLoader : public IAssetLoader
     {
     public:
+        bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const final
+        {
+            return type == std::type_index(typeid(Texture)) && CanLoadTexture(filepath);
+        }
+
         Asset Load(const std::filesystem::path& filepath) final
         {
-            return LoadTexture(filepath);
+            return Asset(LoadTexture(filepath));
         }
 
     protected:
+        virtual bool CanLoadTexture(const std::filesystem::path& filepath) const = 0;
         virtual Ref<Texture> LoadTexture(const std::filesystem::path& filepath) = 0;
     };
 
     class TBX_EXPORT IShaderLoader : public IAssetLoader
     {
     public:
+        bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const final
+        {
+            return type == std::type_index(typeid(Shader)) && CanLoadShader(filepath);
+        }
+
         Asset Load(const std::filesystem::path& filepath) final
         {
-            return LoadShader(filepath);
+            return Asset(LoadShader(filepath));
         }
 
     protected:
+        virtual bool CanLoadShader(const std::filesystem::path& filepath) const = 0;
         virtual Ref<Shader> LoadShader(const std::filesystem::path& filepath) = 0;
     };
 
     class TBX_EXPORT IModelLoader : public IAssetLoader
     {
     public:
+        bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const final
+        {
+            return type == std::type_index(typeid(Model)) && CanLoadModel(filepath);
+        }
+
         Asset Load(const std::filesystem::path& filepath) final
         {
-            return LoadModel(filepath);
+            return Asset(LoadModel(filepath));
         }
 
     protected:
+        virtual bool CanLoadModel(const std::filesystem::path& filepath) const = 0;
         virtual Ref<Model> LoadModel(const std::filesystem::path& filepath) = 0;
     };
 
     class TBX_EXPORT ITextLoader : public IAssetLoader
     {
     public:
+        bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const final
+        {
+            return type == std::type_index(typeid(Text)) && CanLoadText(filepath);
+        }
+
         Asset Load(const std::filesystem::path& filepath) final
         {
-            return LoadText(filepath);
+            return Asset(LoadText(filepath));
         }
 
     protected:
+        virtual bool CanLoadText(const std::filesystem::path& filepath) const = 0;
         virtual Ref<Text> LoadText(const std::filesystem::path& filepath) = 0;
     };
 
     class TBX_EXPORT IAudioLoader : public IAssetLoader
     {
     public:
+        bool CanLoad(std::type_index type, const std::filesystem::path& filepath) const final
+        {
+            return type == std::type_index(typeid(Audio)) && CanLoadAudio(filepath);
+        }
+
         Asset Load(const std::filesystem::path& filepath) final
         {
-            return LoadAudio(filepath);
+            return Asset(LoadAudio(filepath));
         }
 
     protected:
+        virtual bool CanLoadAudio(const std::filesystem::path& filepath) const = 0;
         virtual Ref<Audio> LoadAudio(const std::filesystem::path& filepath) = 0;
     };
 }

--- a/Engine/Source/Tbx/Assets/AssetServer.cpp
+++ b/Engine/Source/Tbx/Assets/AssetServer.cpp
@@ -1,51 +1,9 @@
 #include "Tbx/PCH.h"
 #include "Tbx/Assets/AssetServer.h"
 #include "Tbx/Files/Paths.h"
-#include <array>
-#include <typeindex>
 
 namespace Tbx
 {
-    struct AssetLoaderBinding
-    {
-        std::type_index AssetType = std::type_index(typeid(void));
-        bool (*Matches)(const Ref<IAssetLoader>& loader) = nullptr;
-    };
-
-    static bool IsTextureLoader(const Ref<IAssetLoader>& loader)
-    {
-        return std::dynamic_pointer_cast<ITextureLoader>(loader) != nullptr;
-    }
-
-    static bool IsShaderLoader(const Ref<IAssetLoader>& loader)
-    {
-        return std::dynamic_pointer_cast<IShaderLoader>(loader) != nullptr;
-    }
-     
-    static bool IsModelLoader(const Ref<IAssetLoader>& loader)
-    {
-        return std::dynamic_pointer_cast<IModelLoader>(loader) != nullptr;
-    }
-
-    static bool IsTextLoader(const Ref<IAssetLoader>& loader)
-    {
-        return std::dynamic_pointer_cast<ITextLoader>(loader) != nullptr;
-    }
-
-    static bool IsAudioLoader(const Ref<IAssetLoader>& loader)
-    {
-        return std::dynamic_pointer_cast<IAudioLoader>(loader) != nullptr;
-    }
-
-    static const std::array AssetLoaderBindings =
-    {
-        AssetLoaderBinding{ std::type_index(typeid(Texture)), &IsTextureLoader },
-        AssetLoaderBinding{ std::type_index(typeid(Shader)), &IsShaderLoader },
-        AssetLoaderBinding{ std::type_index(typeid(Model)), &IsModelLoader },
-        AssetLoaderBinding{ std::type_index(typeid(Text)), &IsTextLoader },
-        AssetLoaderBinding{ std::type_index(typeid(Audio)), &IsAudioLoader }
-    };
-
     AssetServer::AssetServer(const std::string& assetsFolderPath, const std::vector<Ref<IAssetLoader>>& loaders)
         : _assetDirectory(std::filesystem::absolute(assetsFolderPath))
     {
@@ -54,7 +12,8 @@ namespace Tbx
 
     void AssetServer::BuildLoaderLookup(const std::vector<Ref<IAssetLoader>>& loaders)
     {
-        _loadersByType.clear();
+        _loaders.clear();
+        _loaders.reserve(loaders.size());
 
         for (const auto& loader : loaders)
         {
@@ -63,13 +22,7 @@ namespace Tbx
                 continue;
             }
 
-            for (const auto& binding : AssetLoaderBindings)
-            {
-                if (binding.Matches && binding.Matches(loader))
-                {
-                    _loadersByType[binding.AssetType].push_back(loader);
-                }
-            }
+            _loaders.push_back(loader);
         }
     }
 


### PR DESCRIPTION
## Summary
- simplify the Asset helper to expose a single templated GetData accessor that returns nullptr on type mismatch
- update AssetServer to use the new accessor when checking loader results
- pull in the updated SDL and TIMS asset loader plugin revisions compatible with the accessor change

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f86586329c83279154dc6cc2afb968