### PR TITLE
Remove factory plugin pattern

### DIFF
--- a/Engine/Include/Tbx/Plugins/Plugin.h
+++ b/Engine/Include/Tbx/Plugins/Plugin.h
@@ -16,37 +16,6 @@ namespace Tbx
         virtual ~Plugin();
     };
 
-    class TBX_EXPORT IProductOfPluginFactory
-    {
-    public:
-        virtual ~IProductOfPluginFactory();
-
-    public:
-        Ref<Plugin> Owner = nullptr;
-    };
-
-    template <typename TProduct>
-    requires std::is_base_of_v<IProductOfPluginFactory, TProduct>
-    class FactoryPlugin : public Plugin, public std::enable_shared_from_this<FactoryPlugin<TProduct>>
-    {
-    public:
-        FactoryPlugin() = default;
-
-        // Create a new instance. The factory ensures plugin ownership is injected.
-        template <typename... Args>
-        Ref<TProduct> Create(Args&&... args)
-        {
-            auto product = Ref<TProduct>(new TProduct(std::forward<Args>(args)...), [&](TProduct* prodToDelete) { Destroy(prodToDelete); });
-            product->Owner = this->shared_from_this();
-            return product;
-        }
-
-        void Destroy(TProduct* product)
-        {
-            delete product;
-        }
-    };
-
     class TBX_EXPORT StaticPlugin
     {
     public:
@@ -61,7 +30,7 @@ namespace Tbx
     #define TBX_LOAD_PLUGIN_FN_NAME "Load"
     #define TBX_UNLOAD_PLUGIN_FN_NAME "Unload"
 
-    // Cross-platform export for the *factories* only:
+    // Cross-platform export for plugins:
     #if defined(TBX_PLATFORM_WINDOWS)
         #define TBX_PLUGIN_EXPORT extern "C" __declspec(dllexport)
     #else

--- a/Engine/Source/Tbx/Plugins/IProductOfPluginFactory.cpp
+++ b/Engine/Source/Tbx/Plugins/IProductOfPluginFactory.cpp
@@ -1,7 +1,0 @@
-#include "Tbx/PCH.h"
-#include "Tbx/Plugins/Plugin.h"
-
-namespace Tbx
-{
-    IProductOfPluginFactory::~IProductOfPluginFactory() = default;
-}

--- a/Plugins/Toybox-SDL-Plugins/Audio/Source/SDL3AudioPlugin.h
+++ b/Plugins/Toybox-SDL-Plugins/Audio/Source/SDL3AudioPlugin.h
@@ -8,7 +8,7 @@
 
 namespace Tbx::Plugins::SDL3Audio
 {
-    struct SDLAudio : public Audio, public IProductOfPluginFactory
+    struct SDLAudio : public Audio
     {
         using Audio::Audio;
     };
@@ -48,7 +48,7 @@ namespace Tbx::Plugins::SDL3Audio
     };
 
     class SDL3AudioPlugin final
-        : public FactoryPlugin<SDLAudio>
+        : public Plugin
         , public IAudioLoader
         , public IAudioMixer
     {

--- a/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContext.h
+++ b/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContext.h
@@ -5,7 +5,7 @@
 
 namespace Tbx::Plugins::SDLGraphicsContext
 {
-    class SDLGLGraphicsContext final : public IGraphicsContext, public IProductOfPluginFactory
+    class SDLGLGraphicsContext final : public IGraphicsContext
     {
     public:
         SDLGLGraphicsContext(SDL_Window* window);

--- a/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContextProviderPlugin.cpp
+++ b/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContextProviderPlugin.cpp
@@ -1,10 +1,11 @@
 #include "Tbx/Debug/Asserts.h"
 #include "SDLGLGraphicsContextProviderPlugin.h"
 #include "SDLGLGraphicsContext.h"
+#include "Tbx/Memory/Refs.h"
 
 namespace Tbx::Plugins::SDLGraphicsContext
 {
-   Ref<Tbx::IGraphicsContext> SDLOpenGlGraphicsContextsProviderPlugin::Provide(const Window* window)
+    Ref<Tbx::IGraphicsContext> SDLOpenGlGraphicsContextsProviderPlugin::Provide(const Window* window)
     {
         if (!window)
         {
@@ -12,7 +13,7 @@ namespace Tbx::Plugins::SDLGraphicsContext
             return nullptr;
         }
         auto* sdlWindow = std::any_cast<SDL_Window*>(window->GetNativeWindow());
-        return Create(sdlWindow);
+        return MakeRef<SDLGLGraphicsContext>(sdlWindow);
     }
 
     GraphicsApi SDLOpenGlGraphicsContextsProviderPlugin::GetApi() const

--- a/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContextProviderPlugin.h
+++ b/Plugins/Toybox-SDL-Plugins/GraphicsContexts/OpenGl/Source/SDLGLGraphicsContextProviderPlugin.h
@@ -1,4 +1,4 @@
-#pragma
+#pragma once
 #include "SDLGLGraphicsContext.h"
 #include "Tbx/Plugins/Plugin.h"
 #include "Tbx/Graphics/GraphicsContext.h"
@@ -7,7 +7,7 @@
 namespace Tbx::Plugins::SDLGraphicsContext
 {
     class SDLOpenGlGraphicsContextsProviderPlugin final
-        : public FactoryPlugin<SDLGLGraphicsContext>
+        : public Plugin
         , public IGraphicsContextProvider
     {
     public:

--- a/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindow.h
+++ b/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindow.h
@@ -6,7 +6,7 @@
 
 namespace Tbx::Plugins::SDLWindowing
 {
-    class SDLWindow : public Window, public IProductOfPluginFactory
+    class SDLWindow : public Window
     {
     public:
         SDLWindow(bool useOpenGl, Ref<EventBus> eventBus);

--- a/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindowFactoryPlugin.cpp
+++ b/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindowFactoryPlugin.cpp
@@ -1,5 +1,6 @@
 #include "SDLWindowFactoryPlugin.h"
 #include "SDLWindow.h"
+#include "Tbx/Memory/Refs.h"
 #include <SDL3/SDL_init.h>
 
 namespace Tbx::Plugins::SDLWindowing
@@ -25,7 +26,7 @@ namespace Tbx::Plugins::SDLWindowing
 
     std::shared_ptr<Window> SDLWindowFactoryPlugin::Create(const std::string& title, const Size& size, const WindowMode& mode, Ref<EventBus> eventBus)
     {
-        auto window = FactoryPlugin<SDLWindow>::Create(_usingOpenGl, eventBus);
+        auto window = MakeRef<SDLWindow>(_usingOpenGl, eventBus);
         window->SetTitle(title);
         window->SetSize(size);
         window->SetMode(mode);

--- a/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindowFactoryPlugin.h
+++ b/Plugins/Toybox-SDL-Plugins/Windowing/Source/SDLWindowFactoryPlugin.h
@@ -1,4 +1,4 @@
-#pragma 
+#pragma once
 #include "SDLWindow.h"
 #include "Tbx/Plugins/Plugin.h"
 #include "Tbx/Events/AppEvents.h"
@@ -7,7 +7,7 @@
 namespace Tbx::Plugins::SDLWindowing
 {
     class SDLWindowFactoryPlugin final
-        : public FactoryPlugin<SDLWindow>
+        : public Plugin
         , public IWindowFactory
     {
     public:

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Shaders/Source/TIMSShaderLoaderPlugin.cpp
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Shaders/Source/TIMSShaderLoaderPlugin.cpp
@@ -1,5 +1,6 @@
 #include "TIMSShaderLoaderPlugin.h"
 #include "Tbx/Debug/Asserts.h"
+#include "Tbx/Memory/Refs.h"
 #include <stb_image.h>
 #include <fstream>
 #include <sstream>
@@ -57,7 +58,7 @@ namespace Tbx::Plugins::TIMS
         }
 
         // Create tbx in memory shader and return it
-        auto shader = Create(shaderSource, shaderType);
+        auto shader = MakeRef<TIMSShader>(shaderSource, shaderType);
         return shader;
     }
 }

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Shaders/Source/TIMSShaderLoaderPlugin.h
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Shaders/Source/TIMSShaderLoaderPlugin.h
@@ -4,13 +4,13 @@
 
 namespace Tbx::Plugins::TIMS
 {
-    struct TIMSShader : public Shader, public IProductOfPluginFactory
+    struct TIMSShader : public Shader
     {
         using Shader::Shader;
     };
 
     class TIMSShaderLoaderPlugin final
-        : public FactoryPlugin<TIMSShader>
+        : public Plugin
         , public IShaderLoader
     {
     public:

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Text/Source/TIMSTextLoaderPlugin.cpp
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Text/Source/TIMSTextLoaderPlugin.cpp
@@ -1,5 +1,6 @@
 #include "TIMSTextLoaderPlugin.h"
 #include "Tbx/Debug/Asserts.h"
+#include "Tbx/Memory/Refs.h"
 #include <stb_image.h>
 #include <fstream>
 #include <sstream>
@@ -28,6 +29,6 @@ namespace Tbx::Plugins::TIMS
         contents << file.rdbuf();
         file.close();
 
-        return FactoryPlugin<TIMSText>::Create(contents.str(), "None", 12);
+        return MakeRef<TIMSText>(contents.str(), "None", 12);
     }
 }

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Text/Source/TIMSTextLoaderPlugin.h
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Text/Source/TIMSTextLoaderPlugin.h
@@ -4,13 +4,13 @@
 
 namespace Tbx::Plugins::TIMS
 {
-    struct TIMSText : public Text, public IProductOfPluginFactory
+    struct TIMSText : public Text
     {
         using Text::Text;
     };
 
     class TIMSTextLoaderPlugin final
-        : public FactoryPlugin<TIMSText>
+        : public Plugin
         , public ITextLoader
     {
     public:

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Textures/Source/TIMSTextureLoaderPlugin.cpp
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Textures/Source/TIMSTextureLoaderPlugin.cpp
@@ -1,5 +1,6 @@
 #include "TIMSTextureLoaderPlugin.h"
 #include "Tbx/Debug/Asserts.h"
+#include "Tbx/Memory/Refs.h"
 #include <stb_image.h>
 #include <cstring>
 
@@ -34,7 +35,7 @@ namespace Tbx::Plugins::TIMS
         std::memcpy(pixelData.data(), data, dataSize);
 
         // Create tbx in memory texture and return it
-        auto texture = Create(
+        auto texture = MakeRef<TIMSTexture>(
             Size(width, height),
             TextureWrap::Repeat,
             TextureFilter::Nearest,

--- a/Plugins/Toybox-TIMS-AssetLoader-Plugins/Textures/Source/TIMSTextureLoaderPlugin.h
+++ b/Plugins/Toybox-TIMS-AssetLoader-Plugins/Textures/Source/TIMSTextureLoaderPlugin.h
@@ -4,13 +4,13 @@
 
 namespace Tbx::Plugins::TIMS
 {
-    struct TIMSTexture : public Texture, public IProductOfPluginFactory
+    struct TIMSTexture : public Texture
     {
         using Texture::Texture;
     };
 
     class TIMSTextureLoaderPlugin final
-        : public FactoryPlugin<TIMSTexture>
+        : public Plugin
         , public ITextureLoader
     {
     public:


### PR DESCRIPTION
## Summary
- remove the IProductOfPluginFactory and FactoryPlugin types so plugins no longer need a special factory lifetime
- update SDL and TIMS plugins to derive directly from Plugin and construct their products with MakeRef
- delete the unused factory implementation source file and clean up includes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fa7c9b4668832791111102a2e8eed6