### PR TITLE
Refine try_as outputs and simplify SDL message casting

### DIFF
--- a/engine/include/tbx/logging/logging.h
+++ b/engine/include/tbx/logging/logging.h
@@ -55,7 +55,11 @@ namespace tbx
 
     inline void submit_log(const IMessageDispatcher& dispatcher, LogLevel level, const char* file, int line, const std::string& message)
     {
-        const LogMessageCommand cmd = { .level = level, .message = message, .file = file ? std::string(file) : std::string(), .line = line };
+        LogMessageCommand cmd;
+        cmd.level = level;
+        cmd.message = message;
+        cmd.file = file ? std::string(file) : std::string();
+        cmd.line = line;
         auto result = dispatcher.send(cmd);
         if (!result || !cmd.is_handled)
         {

--- a/engine/include/tbx/math/size.h
+++ b/engine/include/tbx/math/size.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+
+namespace tbx::math
+{
+    struct Size
+    {
+        std::int32_t width = 0;
+        std::int32_t height = 0;
+    };
+}
+

--- a/engine/include/tbx/memory/casting.h
+++ b/engine/include/tbx/memory/casting.h
@@ -24,14 +24,88 @@ namespace tbx
     }
 
     template <typename TTo, typename TFrom>
-    bool try_as(TFrom* ptr, TTo* out)
+    bool try_as(TFrom* ptr, TTo** out)
     {
+        if (out)
+        {
+            *out = nullptr;
+        }
+
+        if (!ptr)
+        {
+            return false;
+        }
+
         TTo* derived = dynamic_cast<TTo*>(ptr);
+        if (out)
+        {
+            *out = derived;
+        }
+        return derived != nullptr;
+    }
+
+    template <typename TTo, typename TFrom>
+    bool try_as(const TFrom* ptr, const TTo** out)
+    {
+        if (out)
+        {
+            *out = nullptr;
+        }
+
+        if (!ptr)
+        {
+            return false;
+        }
+
+        const TTo* derived = dynamic_cast<const TTo*>(ptr);
+        if (out)
+        {
+            *out = derived;
+        }
+        return derived != nullptr;
+    }
+
+    template <typename TTo, typename TFrom>
+    bool try_as(const TFrom* ptr, TTo** out)
+    {
+        if (out)
+        {
+            *out = nullptr;
+        }
+
+        if (!ptr)
+        {
+            return false;
+        }
+
+        const TTo* derived = dynamic_cast<const TTo*>(ptr);
         if (!derived)
         {
             return false;
         }
-        out = derived;
+
+        if (out)
+        {
+            *out = const_cast<TTo*>(derived);
+        }
         return true;
+    }
+
+    template <typename TTo, typename TFrom>
+    bool try_as(TFrom& from, TTo** out)
+    {
+        return try_as<TTo>(&from, out);
+    }
+
+    template <typename TTo, typename TFrom>
+    bool try_as(const TFrom& from, const TTo** out)
+    {
+        return try_as<TTo>(&from, out);
+    }
+
+    template <typename TTo, typename TFrom>
+    bool try_as(const TFrom& from, TTo** out)
+    {
+        return try_as<TTo>(&from, out);
     }
 }

--- a/engine/include/tbx/messages/commands/window_commands.h
+++ b/engine/include/tbx/messages/commands/window_commands.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "tbx/messages/commands/command.h"
+#include "tbx/windowing/window.h"
+#include <utility>
+
+namespace tbx
+{
+    // Command requesting a new platform window.
+    class CreateWindowCommand : public Command
+    {
+    public:
+        CreateWindowCommand() = default;
+        CreateWindowCommand(WindowDescription desc)
+            : description(std::move(desc))
+        {
+        }
+
+        WindowDescription description = {};
+    };
+
+    // Command requesting the latest window state from the platform backend.
+    class QueryWindowDescriptionCommand : public Command
+    {
+    public:
+        QueryWindowDescriptionCommand() = default;
+        QueryWindowDescriptionCommand(Window& window_ref)
+            : window(&window_ref)
+        {
+        }
+
+        Window* window = nullptr;
+    };
+
+    // Command requesting the platform backend to apply a new description.
+    class ApplyWindowDescriptionCommand : public Command
+    {
+    public:
+        ApplyWindowDescriptionCommand() = default;
+        ApplyWindowDescriptionCommand(Window& window_ref, WindowDescription desc)
+            : window(&window_ref)
+            , description(std::move(desc))
+        {
+        }
+
+        Window* window = nullptr;
+        WindowDescription description = {};
+    };
+}

--- a/engine/include/tbx/windowing/window.h
+++ b/engine/include/tbx/windowing/window.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "tbx/ids/uuid.h"
+#include "tbx/math/size.h"
+#include "tbx/messages/dispatcher.h"
+#include <string>
+
+namespace tbx
+{
+    enum class WindowMode
+    {
+        Windowed,
+        Borderless,
+        Fullscreen
+    };
+
+    struct WindowDescription
+    {
+        math::Size size = {1280, 720};
+        WindowMode mode = WindowMode::Windowed;
+        std::string title = "Toybox";
+    };
+
+    using WindowImpl = void*;
+
+    // Window is a lightweight wrapper around a platform specific implementation managed through messages.
+    class Window
+    {
+    public:
+        Window(IMessageDispatcher& dispatcher, WindowImpl implementation, const WindowDescription& description);
+
+        const Uuid& get_id() const;
+        const WindowDescription& get_description();
+        void set_description(const WindowDescription& description);
+
+        WindowImpl get_implementation() const;
+
+    private:
+        void apply_description_update(const WindowDescription& description);
+        void set_implementation(WindowImpl implementation);
+
+        IMessageDispatcher* _dispatcher = nullptr;
+        WindowImpl _implementation = nullptr;
+        WindowDescription _description = {};
+        Uuid _id = Uuid::generate();
+    };
+}

--- a/engine/src/tbx/windowing/window.cpp
+++ b/engine/src/tbx/windowing/window.cpp
@@ -1,0 +1,62 @@
+#include "tbx/windowing/window.h"
+#include "tbx/messages/commands/window_commands.h"
+#include "tbx/state/result.h"
+
+namespace tbx
+{
+    Window::Window(IMessageDispatcher& dispatcher, WindowImpl implementation, const WindowDescription& description)
+        : _dispatcher(&dispatcher)
+        , _implementation(implementation)
+        , _description(description)
+    {
+    }
+
+    const Uuid& Window::get_id() const
+    {
+        return _id;
+    }
+
+    const WindowDescription& Window::get_description()
+    {
+        if (_dispatcher)
+        {
+            QueryWindowDescriptionCommand command(*this);
+            Result result = _dispatcher->send(command);
+            if (result && result.has_payload<WindowDescription>())
+            {
+                apply_description_update(result.get_payload<WindowDescription>());
+            }
+        }
+        return _description;
+    }
+
+    void Window::set_description(const WindowDescription& description)
+    {
+        if (_dispatcher)
+        {
+            ApplyWindowDescriptionCommand command(*this, description);
+            Result result = _dispatcher->send(command);
+            if (result && result.has_payload<WindowDescription>())
+            {
+                apply_description_update(result.get_payload<WindowDescription>());
+                return;
+            }
+        }
+        apply_description_update(description);
+    }
+
+    void Window::apply_description_update(const WindowDescription& description)
+    {
+        _description = description;
+    }
+
+    WindowImpl Window::get_implementation() const
+    {
+        return _implementation;
+    }
+
+    void Window::set_implementation(WindowImpl implementation)
+    {
+        _implementation = implementation;
+    }
+}

--- a/engine/tests/dispatcher_tests.cpp
+++ b/engine/tests/dispatcher_tests.cpp
@@ -421,7 +421,6 @@ namespace tbx::tests::messages
         auto value = result.try_get_payload<int>();
         ASSERT_NE(value, nullptr);
         EXPECT_EQ(*value, 123);
-        EXPECT_EQ(result.payload_or<int>(0), 123);
         EXPECT_EQ(result.try_get_payload<float>(), nullptr);
     }
 
@@ -448,6 +447,8 @@ namespace tbx::tests::messages
 
         EXPECT_EQ(result.get_status(), ::tbx::MessageStatus::Handled);
         EXPECT_TRUE(result.has_payload());
-        EXPECT_EQ(result.payload_or<std::string>(""), "ready");
+        const auto* final_value = result.try_get_payload<std::string>();
+        ASSERT_NE(final_value, nullptr);
+        EXPECT_EQ(*final_value, "ready");
     }
 }

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.26)
 set(CMAKE_FOLDER "Plugins")
 
 add_subdirectory(spdlogger)
+add_subdirectory(sdladapter)
+add_subdirectory(sdlwindowing)
 
 unset(CMAKE_FOLDER)
 

--- a/plugins/sdladapter/CMakeLists.txt
+++ b/plugins/sdladapter/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(SdlAdapterPlugin SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_adapter_plugin.cpp
+)
+
+target_link_libraries(SdlAdapterPlugin PRIVATE
+    Engine
+    SDL3::SDL3
+)
+
+add_custom_command(TARGET SdlAdapterPlugin POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugin.meta
+            $<TARGET_FILE_DIR:SdlAdapterPlugin>/SdlAdapterPlugin.meta)
+
+add_library(Tbx::Plugins::SdlAdapterPlugin ALIAS SdlAdapterPlugin)

--- a/plugins/sdladapter/plugin.meta
+++ b/plugins/sdladapter/plugin.meta
@@ -1,0 +1,8 @@
+{
+    "id": "System.SDL",
+    "name": "SDL Adapter",
+    "version": "1.0.0",
+    "entryPoint": "CreateSdlAdapterPlugin",
+    "type": "system",
+    "module": "SdlAdapterPlugin"
+}

--- a/plugins/sdladapter/src/sdl_adapter_plugin.cpp
+++ b/plugins/sdladapter/src/sdl_adapter_plugin.cpp
@@ -1,0 +1,121 @@
+#include "tbx/logging/log_macros.h"
+#include "tbx/plugin_api/plugin.h"
+#include <SDL3/SDL.h>
+
+namespace tbx::plugins::sdladapter
+{
+    class SdlAdapterPlugin final : public Plugin
+    {
+    public:
+        void on_attach(const ApplicationContext&, IMessageDispatcher&) override
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            install_error_hook();
+
+            const Uint32 mask = SDL_INIT_EVENTS;
+            if ((SDL_WasInit(mask) & mask) == mask)
+            {
+                _initialized = true;
+                _owns_sdl = false;
+                TBX_TRACE_WARNING("SDL events subsystem already initialized; adapter will not manage shutdown.");
+                return;
+            }
+
+            if (SDL_InitSubSystem(mask) < 0)
+            {
+                TBX_TRACE_ERROR("Failed to initialize SDL events subsystem. See SDL logs for details.");
+                TBX_ASSERT(false, "SDL adapter failed to initialize events subsystem. See SDL logs for details.");
+                _initialized = false;
+                _owns_sdl = false;
+                return;
+            }
+
+            _initialized = true;
+            _owns_sdl = true;
+            TBX_TRACE_INFO("SDL adapter initialized the events subsystem.");
+        }
+
+        void on_detach() override
+        {
+            if (_initialized && _owns_sdl)
+            {
+                SDL_QuitSubSystem(SDL_INIT_EVENTS);
+            }
+
+            _initialized = false;
+            _owns_sdl = false;
+
+            remove_error_hook();
+        }
+
+        void on_update(const DeltaTime&) override
+        {
+        }
+
+        void on_message(const Message&) override
+        {
+        }
+
+    private:
+        static void log_sdl_output(void* userdata, int category, SDL_LogPriority priority, const char* message)
+        {
+            auto* plugin = static_cast<SdlAdapterPlugin*>(userdata);
+
+            if (priority >= SDL_LOG_PRIORITY_ERROR)
+            {
+                const char* text = (message && *message) ? message : "SDL reported an error without details.";
+                if (priority == SDL_LOG_PRIORITY_CRITICAL)
+                {
+                    TBX_TRACE_ERROR("SDL critical (category {}): {}", category, text);
+                }
+                else
+                {
+                    TBX_TRACE_ERROR("SDL error (category {}): {}", category, text);
+                }
+            }
+
+            if (plugin && plugin->_previous_log_callback)
+            {
+                plugin->_previous_log_callback(plugin->_previous_log_userdata, category, priority, message);
+            }
+        }
+
+        void install_error_hook()
+        {
+            if (_log_hook_installed)
+            {
+                return;
+            }
+
+            SDL_GetLogOutputFunction(&_previous_log_callback, &_previous_log_userdata);
+            SDL_SetLogOutputFunction(&SdlAdapterPlugin::log_sdl_output, this);
+            _log_hook_installed = true;
+        }
+
+        void remove_error_hook()
+        {
+            if (!_log_hook_installed)
+            {
+                return;
+            }
+
+            SDL_SetLogOutputFunction(_previous_log_callback, _previous_log_userdata);
+            _previous_log_callback = nullptr;
+            _previous_log_userdata = nullptr;
+            _log_hook_installed = false;
+        }
+
+        bool _initialized = false;
+        bool _owns_sdl = false;
+        SDL_LogOutputFunction _previous_log_callback = nullptr;
+        void* _previous_log_userdata = nullptr;
+        bool _log_hook_installed = false;
+    };
+
+    TBX_REGISTER_PLUGIN(CreateSdlAdapterPlugin, SdlAdapterPlugin);
+}
+

--- a/plugins/sdlwindowing/CMakeLists.txt
+++ b/plugins/sdlwindowing/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(SdlWindowingPlugin SHARED
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/sdl_windowing_plugin.cpp
+)
+
+target_link_libraries(SdlWindowingPlugin PRIVATE
+    Engine
+    SDL3::SDL3
+)
+
+add_custom_command(TARGET SdlWindowingPlugin POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_CURRENT_SOURCE_DIR}/plugin.meta
+            $<TARGET_FILE_DIR:SdlWindowingPlugin>/SdlWindowingPlugin.meta)
+
+add_library(Tbx::Plugins::SdlWindowingPlugin ALIAS SdlWindowingPlugin)

--- a/plugins/sdlwindowing/plugin.meta
+++ b/plugins/sdlwindowing/plugin.meta
@@ -1,0 +1,9 @@
+{
+    "id": "Windowing.SDL",
+    "name": "SDL Windowing",
+    "version": "1.0.0",
+    "entryPoint": "CreateSdlWindowingPlugin",
+    "type": "windowing",
+    "module": "SdlWindowingPlugin",
+    "dependencies": ["System.SDL"]
+}

--- a/plugins/sdlwindowing/src/sdl_windowing_plugin.cpp
+++ b/plugins/sdlwindowing/src/sdl_windowing_plugin.cpp
@@ -1,0 +1,340 @@
+#include "tbx/logging/log_macros.h"
+#include "tbx/memory/casting.h"
+#include "tbx/memory/smart_pointers.h"
+#include "tbx/messages/commands/window_commands.h"
+#include "tbx/plugin_api/plugin.h"
+#include "tbx/windowing/window.h"
+#include <SDL3/SDL.h>
+#include <algorithm>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace tbx::plugins::sdlwindowing
+{
+    static WindowMode resolve_window_mode(SDL_Window* window, WindowMode fallback)
+    {
+        const Uint32 flags = SDL_GetWindowFlags(window);
+        if ((flags & SDL_WINDOW_FULLSCREEN) == SDL_WINDOW_FULLSCREEN)
+        {
+            return WindowMode::Fullscreen;
+        }
+        if ((flags & SDL_WINDOW_BORDERLESS) == SDL_WINDOW_BORDERLESS)
+        {
+            return WindowMode::Borderless;
+        }
+        return fallback;
+    }
+
+    static WindowDescription read_window_description(SDL_Window* window, const WindowDescription& fallback)
+    {
+        WindowDescription description = fallback;
+
+        int width = description.size.width;
+        int height = description.size.height;
+        SDL_GetWindowSize(window, &width, &height);
+        description.size.width = width;
+        description.size.height = height;
+
+        description.mode = resolve_window_mode(window, description.mode);
+
+        if (const char* title = SDL_GetWindowTitle(window); title)
+        {
+            description.title = title;
+        }
+
+        return description;
+    }
+
+    static bool apply_window_mode(SDL_Window* window, WindowMode mode)
+    {
+        switch (mode)
+        {
+            case WindowMode::Windowed:
+            {
+                const bool fullscreen_cleared = SDL_SetWindowFullscreen(window, false);
+                const bool bordered = SDL_SetWindowBordered(window, true);
+                return fullscreen_cleared && bordered;
+            }
+            case WindowMode::Borderless:
+            {
+                const bool fullscreen_cleared = SDL_SetWindowFullscreen(window, false);
+                const bool borderless = SDL_SetWindowBordered(window, false);
+                return fullscreen_cleared && borderless;
+            }
+            case WindowMode::Fullscreen:
+                return SDL_SetWindowFullscreen(window, true);
+        }
+
+        return false;
+    }
+
+    static bool apply_window_description(SDL_Window* window, const WindowDescription& description)
+    {
+        bool succeeded = true;
+
+        if (description.size.width > 0 && description.size.height > 0)
+        {
+            succeeded = SDL_SetWindowSize(window, description.size.width, description.size.height) && succeeded;
+        }
+
+        succeeded = SDL_SetWindowTitle(window, description.title.c_str()) && succeeded;
+        succeeded = apply_window_mode(window, description.mode) && succeeded;
+
+        if (succeeded)
+        {
+            SDL_ShowWindow(window);
+        }
+
+        return succeeded;
+    }
+
+    struct SdlWindowRecord
+    {
+        SdlWindowRecord(IMessageDispatcher& dispatcher, SDL_Window* native_window, const WindowDescription& description)
+            : window(dispatcher, static_cast<void*>(native_window), description)
+            , description(description)
+            , native(native_window)
+        {
+        }
+
+        Window window;
+        WindowDescription description = {};
+        SDL_Window* native = nullptr;
+    };
+
+    class SdlWindowingPlugin final : public Plugin
+    {
+    public:
+        void on_attach(const ApplicationContext&, IMessageDispatcher& dispatcher) override
+        {
+            _dispatcher = &dispatcher;
+
+            if ((SDL_WasInit(SDL_INIT_VIDEO) & SDL_INIT_VIDEO) != SDL_INIT_VIDEO)
+            {
+                if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
+                {
+                    TBX_TRACE_ERROR("Failed to initialize SDL video subsystem. See SDL logs for details.");
+                    return;
+                }
+
+                _owns_video = true;
+                TBX_TRACE_INFO("SDL windowing initialized the video subsystem.");
+            }
+        }
+
+        void on_detach() override
+        {
+            for (auto& record : _windows)
+            {
+                if (record->native)
+                {
+                    SDL_DestroyWindow(record->native);
+                    record->native = nullptr;
+                }
+            }
+            _windows.clear();
+
+            if (_owns_video)
+            {
+                SDL_QuitSubSystem(SDL_INIT_VIDEO);
+                _owns_video = false;
+            }
+
+            _dispatcher = nullptr;
+        }
+
+        void on_update(const DeltaTime&) override
+        {
+            if (SDL_WasInit(SDL_INIT_VIDEO))
+            {
+                SDL_PumpEvents();
+            }
+        }
+
+        void on_message(const Message& msg) override
+        {
+            CreateWindowCommand* create = nullptr;
+            if (try_as(msg, &create))
+            {
+                handle_create_window(*create);
+                return;
+            }
+
+            QueryWindowDescriptionCommand* query = nullptr;
+            if (try_as(msg, &query))
+            {
+                handle_query_description(*query);
+                return;
+            }
+
+            ApplyWindowDescriptionCommand* apply = nullptr;
+            if (try_as(msg, &apply))
+            {
+                handle_apply_description(*apply);
+            }
+        }
+
+    private:
+        void handle_create_window(CreateWindowCommand& command)
+        {
+            Result* result = command.get_result();
+
+            if (!_dispatcher)
+            {
+                set_failure(result, "Window dispatcher is not available.");
+                command.is_handled = true;
+                return;
+            }
+
+            if ((SDL_WasInit(SDL_INIT_VIDEO) & SDL_INIT_VIDEO) != SDL_INIT_VIDEO)
+            {
+                set_failure(result, "SDL video subsystem is not initialized.");
+                command.is_handled = true;
+                return;
+            }
+
+            const WindowDescription& requested = command.description;
+            if (requested.size.width <= 0 || requested.size.height <= 0)
+            {
+                set_failure(result, "Window dimensions must be positive.");
+                command.is_handled = true;
+                return;
+            }
+
+            Uint32 flags = SDL_WINDOW_RESIZABLE;
+            if (requested.mode == WindowMode::Borderless)
+            {
+                flags |= SDL_WINDOW_BORDERLESS;
+            }
+            else if (requested.mode == WindowMode::Fullscreen)
+            {
+                flags |= SDL_WINDOW_FULLSCREEN;
+            }
+
+            SDL_Window* native = SDL_CreateWindow(requested.title.c_str(), requested.size.width, requested.size.height, flags);
+            if (!native)
+            {
+                TBX_TRACE_ERROR("Failed to create SDL window. See SDL logs for details.");
+                set_failure(result, "Failed to create SDL window.");
+                command.is_handled = true;
+                return;
+            }
+
+            if (!apply_window_description(native, requested))
+            {
+                TBX_TRACE_WARNING("SDL window created but initial description could not be fully applied. See SDL logs for details.");
+            }
+
+            const WindowDescription description = read_window_description(native, requested);
+
+            auto record = tbx::make_scope<SdlWindowRecord>(*_dispatcher, native, description);
+
+            if (result)
+            {
+                result->set_payload<Window*>(&record->window);
+                result->set_status(ResultStatus::Handled);
+            }
+
+            _windows.push_back(std::move(record));
+            command.is_handled = true;
+        }
+
+        static void set_failure(Result* result, std::string_view reason)
+        {
+            if (!result)
+            {
+                return;
+            }
+            result->reset_payload();
+            result->set_status(ResultStatus::Failed, std::string(reason));
+        }
+
+        void handle_query_description(QueryWindowDescriptionCommand& command)
+        {
+            Result* result = command.get_result();
+
+            if (!command.window)
+            {
+                set_failure(result, "Query missing window reference.");
+                command.is_handled = true;
+                return;
+            }
+
+            SdlWindowRecord* record = find_record(*command.window);
+            if (!record)
+            {
+                set_failure(result, "Window is not managed by SDL windowing.");
+                command.is_handled = true;
+                return;
+            }
+
+            const WindowDescription description = read_window_description(record->native, record->description);
+            record->description = description;
+            if (result)
+            {
+                result->set_payload(description);
+                result->set_status(ResultStatus::Handled);
+            }
+
+            command.is_handled = true;
+        }
+
+        void handle_apply_description(ApplyWindowDescriptionCommand& command)
+        {
+            Result* result = command.get_result();
+
+            if (!command.window)
+            {
+                set_failure(result, "Apply missing window reference.");
+                command.is_handled = true;
+                return;
+            }
+
+            SdlWindowRecord* record = find_record(*command.window);
+            if (!record)
+            {
+                set_failure(result, "Window is not managed by SDL windowing.");
+                command.is_handled = true;
+                return;
+            }
+
+            if (!apply_window_description(record->native, command.description))
+            {
+                set_failure(result, "Failed to apply SDL window description.");
+                command.is_handled = true;
+                return;
+            }
+
+            const WindowDescription refreshed = read_window_description(record->native, command.description);
+            record->description = refreshed;
+            if (result)
+            {
+                result->set_payload(refreshed);
+                result->set_status(ResultStatus::Handled);
+            }
+
+            command.is_handled = true;
+        }
+
+        SdlWindowRecord* find_record(const Window& window) const
+        {
+            auto it = std::find_if(_windows.begin(), _windows.end(), [&window](const Scope<SdlWindowRecord>& record) {
+                return &record->window == &window;
+            });
+            if (it == _windows.end())
+            {
+                return nullptr;
+            }
+            return it->get();
+        }
+
+        std::vector<Scope<SdlWindowRecord>> _windows = {};
+        IMessageDispatcher* _dispatcher = nullptr;
+        bool _owns_video = false;
+    };
+
+    TBX_REGISTER_PLUGIN(CreateSdlWindowingPlugin, SdlWindowingPlugin);
+}
+


### PR DESCRIPTION
## Summary
- adjust the try_as helpers to accept pointer outputs, reset them on failure, and provide reference overloads
- update the SDL windowing plugin to call the refined try_as helpers without redundant namespace qualifiers

## Testing
- cmake --build --preset tbx-ninja-debug
- ctest --preset tbx-test-ninja-debug

------
https://chatgpt.com/codex/tasks/task_e_69050a238f948327a0d8029bf2fba959