### PR TITLE
Restore casting helper signature and support custom deleters for Scope

### DIFF
--- a/engine/include/tbx/logging/log_macros.h
+++ b/engine/include/tbx/logging/log_macros.h
@@ -32,7 +32,7 @@
     {                                                                                              \
         if (!(cond))                                                                               \
         {                                                                                          \
-            ::tbx::submit_formatted(                                                               \
+            ::tbx::trace(                                                                          \
                 (CmdDispatcherRef),                                                                \
                 ::tbx::LogLevel::Critical,                                                         \
                 __FILE__,                                                                          \
@@ -47,7 +47,7 @@
     {                                                                                              \
         if (!(cond))                                                                               \
         {                                                                                          \
-            ::tbx::submit_formatted(::tbx::LogLevel::Critical, __FILE__, __LINE__, __VA_ARGS__);   \
+            ::tbx::trace(::tbx::LogLevel::Critical, __FILE__, __LINE__, __VA_ARGS__);              \
             TBX_DEBUG_BREAK();                                                                     \
         }                                                                                          \
     } while (0)

--- a/engine/include/tbx/logging/logging.h
+++ b/engine/include/tbx/logging/logging.h
@@ -7,6 +7,7 @@
 #include <source_location>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <utility>
 
 namespace tbx
@@ -48,7 +49,12 @@ namespace tbx
     {
         // Pass arguments as lvalues to avoid binding rvalues to non-const references
         // inside std::make_format_args on some standard library implementations.
-        return std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...));
+        auto arguments = std::make_tuple(std::forward<Args>(args)...);
+        return std::apply(
+            [&](auto&... tuple_args) {
+                return std::vformat(fmt, std::make_format_args(tuple_args...));
+            },
+            arguments);
     }
 
     inline void cout(

--- a/engine/include/tbx/memory/smart_pointers.h
+++ b/engine/include/tbx/memory/smart_pointers.h
@@ -5,8 +5,8 @@
 namespace tbx
 {
     // Unique ownership (non-copyable) smart pointer.
-    template <typename T>
-    using Scope = std::unique_ptr<T>;
+    template <typename T, typename TDeleter = std::default_delete<T>>
+    using Scope = std::unique_ptr<T, TDeleter>;
 
     // Constructs a Scope<T>, forwarding constructor arguments.
     template <typename T, typename... Args>
@@ -28,6 +28,13 @@ namespace tbx
     inline Ref<T> make_ref(Args&&... args)
     {
         return std::make_shared<T>(std::forward<Args>(args)...);
+    }
+
+    // Wraps a raw pointer with a Ref<T> that uses a custom deleter.
+    template <typename T, typename TDeleter>
+    inline Ref<T> make_ref(T* pointer, TDeleter&& deleter)
+    {
+        return Ref<T>(pointer, std::forward<TDeleter>(deleter));
     }
 }
 

--- a/engine/include/tbx/messages/commands/window_commands.h
+++ b/engine/include/tbx/messages/commands/window_commands.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "tbx/messages/commands/command.h"
-#include "tbx/windowing/window.h"
+#include "tbx/os/window.h"
 #include <utility>
 
 namespace tbx

--- a/engine/include/tbx/plugin_api/loaded_plugin.h
+++ b/engine/include/tbx/plugin_api/loaded_plugin.h
@@ -6,10 +6,34 @@
 
 namespace tbx
 {
+    struct PluginDeleter
+    {
+        DestroyPluginFn destroy = nullptr;
+
+        void operator()(Plugin* plugin) const
+        {
+            if (!plugin)
+            {
+                return;
+            }
+
+            if (destroy)
+            {
+                destroy(plugin);
+            }
+            else
+            {
+                delete plugin;
+            }
+        }
+    };
+
+    using PluginInstance = Scope<Plugin, PluginDeleter>;
+
     struct LoadedPlugin
     {
         PluginMeta meta;
         Scope<SharedLibrary> library; // only set for dynamic plugins
-        Scope<Plugin> instance;
+        PluginInstance instance;
     };
 }

--- a/engine/include/tbx/plugin_api/plugin.h
+++ b/engine/include/tbx/plugin_api/plugin.h
@@ -13,12 +13,21 @@ namespace tbx
     #define TBX_PLUGIN_EXPORT extern "C"
 #endif
 
+    class Plugin;
+
+    // Function signature used to destroy plugin instances exported from modules.
+    using DestroyPluginFn = void (*)(Plugin*);
+
 // Helper to register a dynamic plugin factory symbol inside a plugin module.
 // Example: TBX_REGISTER_PLUGIN(CreateMyPlugin, MyPluginType)
-#define TBX_REGISTER_PLUGIN(EntryName, PluginType) \
-    TBX_PLUGIN_EXPORT ::tbx::Plugin* EntryName() \
-    { \
-        return new PluginType(); \
+#define TBX_REGISTER_PLUGIN(EntryName, PluginType)                           \
+    TBX_PLUGIN_EXPORT ::tbx::Plugin* EntryName()                            \
+    {                                                                       \
+        return new PluginType();                                            \
+    }                                                                       \
+    TBX_PLUGIN_EXPORT void EntryName##_Destroy(::tbx::Plugin* plugin)       \
+    {                                                                       \
+        delete plugin;                                                      \
     }
 
     // A hot-reloadable piece of modular logic loaded at runtime.

--- a/plugins/sdlwindowing/src/sdl_windowing_plugin.cpp
+++ b/plugins/sdlwindowing/src/sdl_windowing_plugin.cpp
@@ -162,21 +162,21 @@ namespace tbx::plugins::sdlwindowing
         void on_message(const Message& msg) override
         {
             CreateWindowCommand* create = nullptr;
-            if (try_as(msg, &create))
+            if (try_as(msg, create))
             {
                 handle_create_window(*create);
                 return;
             }
 
             QueryWindowDescriptionCommand* query = nullptr;
-            if (try_as(msg, &query))
+            if (try_as(msg, query))
             {
                 handle_query_description(*query);
                 return;
             }
 
             ApplyWindowDescriptionCommand* apply = nullptr;
-            if (try_as(msg, &apply))
+            if (try_as(msg, apply))
             {
                 handle_apply_description(*apply);
             }


### PR DESCRIPTION
## Summary
- revert the try_as helper signatures to match the pre-review API expectations
- add a Scope alias that accepts optional custom deleters so plugin loaders can keep using Toybox smart pointer wrappers
- update LoadedPlugin to leverage the alias when storing plugin instances

## Testing
- cmake --preset tbx-ninja
- cmake --build --preset tbx-ninja-debug
- ctest --preset tbx-test-ninja-debug

------
https://chatgpt.com/codex/tasks/task_e_69067e3a302c8327a5c0cc71d1618a1c