### PR TITLE
Prevent copying queued messages in coordinator

### DIFF
--- a/engine/include/tbx/messages/coordinator.h
+++ b/engine/include/tbx/messages/coordinator.h
@@ -16,6 +16,13 @@ namespace tbx
         Scope<Message> message;
         Result result;
         Timer timer;
+
+        QueuedMessage() = default;
+        QueuedMessage(const QueuedMessage&) = delete;
+        QueuedMessage& operator=(const QueuedMessage&) = delete;
+        QueuedMessage(QueuedMessage&&) noexcept = default;
+        QueuedMessage& operator=(QueuedMessage&&) noexcept = default;
+        ~QueuedMessage() = default;
     };
 
     // Concrete coordinator that (not thread-safe; callers serialize access):
@@ -26,6 +33,13 @@ namespace tbx
     class TBX_API MessageCoordinator : public IMessageDispatcher, public IMessageProcessor
     {
        public:
+        MessageCoordinator() = default;
+        MessageCoordinator(const MessageCoordinator&) = delete;
+        MessageCoordinator& operator=(const MessageCoordinator&) = delete;
+        MessageCoordinator(MessageCoordinator&&) noexcept = default;
+        MessageCoordinator& operator=(MessageCoordinator&&) noexcept = default;
+        ~MessageCoordinator() = default;
+
         Uuid add_handler(MessageHandler handler);
         void remove_handler(const Uuid& token);
         void clear();


### PR DESCRIPTION
## Summary
- disable copy semantics for `tbx::QueuedMessage` so the queued message queue remains move-only
- delete copy operations on `tbx::MessageCoordinator` while defaulting move semantics for vector storage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907acbeb9a08327846feef934533871