### PR TITLE
Ensure module outputs use shared directories

### DIFF
--- a/cmake/TbxModules.cmake
+++ b/cmake/TbxModules.cmake
@@ -21,12 +21,32 @@ function(tbx_add_module target_name)
         add_library(${target_name} STATIC)
     endif()
 
+    set(runtime_output_directory "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+    if(runtime_output_directory AND NOT runtime_output_directory MATCHES "\$<CONFIG>")
+        set(runtime_output_directory "${runtime_output_directory}/$<CONFIG>")
+    endif()
+
+    set(library_output_directory "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+    if(library_output_directory AND NOT library_output_directory MATCHES "\$<CONFIG>")
+        set(library_output_directory "${library_output_directory}/$<CONFIG>")
+    endif()
+
+    set(archive_output_directory "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}")
+    if(archive_output_directory AND NOT archive_output_directory MATCHES "\$<CONFIG>")
+        set(archive_output_directory "${archive_output_directory}/$<CONFIG>")
+    endif()
+
+    set(pdb_output_directory "${CMAKE_PDB_OUTPUT_DIRECTORY}")
+    if(pdb_output_directory AND NOT pdb_output_directory MATCHES "\$<CONFIG>")
+        set(pdb_output_directory "${pdb_output_directory}/$<CONFIG>")
+    endif()
+
     set_target_properties(${target_name}
         PROPERTIES
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
-            LIBRARY_OUTPUT_DIRECTORY "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
-            ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}"
-            PDB_OUTPUT_DIRECTORY "${CMAKE_PDB_OUTPUT_DIRECTORY}"
+            RUNTIME_OUTPUT_DIRECTORY "${runtime_output_directory}"
+            LIBRARY_OUTPUT_DIRECTORY "${library_output_directory}"
+            ARCHIVE_OUTPUT_DIRECTORY "${archive_output_directory}"
+            PDB_OUTPUT_DIRECTORY "${pdb_output_directory}"
             CXX_STANDARD 23
             CXX_STANDARD_REQUIRED YES
             CXX_EXTENSIONS NO


### PR DESCRIPTION
## Summary
- set module targets to use the configured runtime, library, archive, and pdb output directories
- keep build artifacts in consistent shared folders for downstream linking

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb665858083278057cb342517370f)