### PR TITLE
Simplify GitHub Actions to one fail-fast uncached build

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -18,38 +18,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_fast:
-    if: github.event_name == 'pull_request'
+  build:
     uses: ./.github/workflows/cmake-platform-build.yml
     with:
-      use-cache: true
-      fail-fast: true
       matrix-config: >-
         {"include":[
-          {"os":"windows-latest","configure_preset":"msvc","build_preset":"msvc-release","test_preset":"test-msvc-release","compiler_launcher":"sccache"},
-          {"os":"ubuntu-latest","configure_preset":"clang","build_preset":"clang-release","test_preset":"test-clang-release","compiler_launcher":"ccache"}
-        ]}
-
-  cache_seed:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/cmake-platform-build.yml
-    with:
-      use-cache: true
-      fail-fast: false
-      matrix-config: >-
-        {"include":[
-          {"os":"windows-latest","configure_preset":"msvc","build_preset":"msvc-release","test_preset":"test-msvc-release","compiler_launcher":"sccache"},
-          {"os":"ubuntu-latest","configure_preset":"clang","build_preset":"clang-release","test_preset":"test-clang-release","compiler_launcher":"ccache"}
-        ]}
-
-  build_full:
-    if: github.event_name != 'pull_request'
-    uses: ./.github/workflows/cmake-platform-build.yml
-    with:
-      use-cache: false
-      fail-fast: false
-      matrix-config: >-
-        {"include":[
-          {"os":"windows-latest","configure_preset":"msvc","build_preset":"msvc-release","test_preset":"test-msvc-release","compiler_launcher":""},
-          {"os":"ubuntu-latest","configure_preset":"clang","build_preset":"clang-release","test_preset":"test-clang-release","compiler_launcher":""}
+          {"os":"windows-latest","configure_preset":"msvc","build_preset":"msvc-release","test_preset":"test-msvc-release"},
+          {"os":"ubuntu-latest","configure_preset":"clang","build_preset":"clang-release","test_preset":"test-clang-release"}
         ]}

--- a/.github/workflows/cmake-platform-build.yml
+++ b/.github/workflows/cmake-platform-build.yml
@@ -3,130 +3,75 @@ name: CMake platform build
 on:
   workflow_call:
     inputs:
-      use-cache:
-        description: Whether to enable compiler caches during setup.
-        required: true
-        type: boolean
       matrix-config:
         description: JSON-encoded matrix configuration.
         required: true
         type: string
-      fail-fast:
-        description: Whether to stop early on first failure.
-        required: true
-        type: boolean
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    env:
-      CACHE_VERSION: v1
-      SCCACHE_DIR: ${{ github.workspace }}/sccache
 
     strategy:
-      fail-fast: ${{ inputs.fail-fast }}
+      fail-fast: true
       matrix: ${{ fromJSON(inputs.matrix-config) }}
 
     steps:
+      - name: Check out repository
+        # Pull repository contents and submodules.
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-    - name: Check out repository
-      # Pull repository contents and submodules.
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+      - name: Set up CMake 4.1.0
+        # Install the requested CMake version.
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '4.1.0'
 
-    - name: Set up CMake 4.1.0
-      # Install the requested CMake version.
-      uses: jwlawson/actions-setup-cmake@v2
-      with:
-        cmake-version: '4.1.0'
+      - name: Setup (Windows)
+        # Windows runners are ready for MSVC once the environment is configured.
+        if: runner.os == 'Windows'
+        run: echo "Windows setup complete."
 
-    - name: Setup (Windows)
-      # Prepare the Windows toolchain and cache when enabled.
-      if: runner.os == 'Windows' && inputs.use-cache
-      uses: ./.github/actions/windows-setup
-      with:
-        sccache-dir: ${{ env.SCCACHE_DIR }}
-        cache-key: ${{ runner.os }}-sccache-${{ matrix.configure_preset }}-${{ matrix.build_preset }}-${{ env.CACHE_VERSION }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**', 'modules/**', 'plugins/**', 'thirdparty/**') }}
-        cache-restore-keys: |
-          ${{ runner.os }}-sccache-${{ matrix.configure_preset }}-${{ matrix.build_preset }}-${{ env.CACHE_VERSION }}-
-          ${{ runner.os }}-sccache-${{ matrix.configure_preset }}-${{ env.CACHE_VERSION }}-
-          ${{ runner.os }}-sccache-${{ env.CACHE_VERSION }}-
+      - name: Configure MSVC environment
+        # Ensure cl.exe is available on PATH for preset compiler selection.
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
 
-    - name: Setup (Windows, no cache)
-      # Log that Windows builds intentionally skip caches.
-      if: runner.os == 'Windows' && !inputs.use-cache
-      run: echo "Windows setup complete; full builds run without caching."
+      - name: Setup (Linux)
+        # Install Linux dependencies required by the build presets.
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev
 
-    - name: Configure MSVC environment
-      # Ensure cl.exe is available on PATH for preset compiler selection.
-      if: runner.os == 'Windows'
-      uses: ilammy/msvc-dev-cmd@v1
+      - name: Build (Windows)
+        # Configure and build using presets, then run tests.
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -e
+          cmake --preset "${{ matrix.configure_preset }}"
+          cmake --build --preset "${{ matrix.build_preset }}"
+          ctest --preset "${{ matrix.test_preset }}"
 
-    - name: Setup (Linux)
-      # Install Linux dependencies and restore the compiler cache when enabled.
-      if: runner.os == 'Linux' && inputs.use-cache
-      uses: ./.github/actions/linux-setup
-      with:
-        cache-key: ${{ runner.os }}-ccache-${{ matrix.configure_preset }}-${{ matrix.build_preset }}-${{ env.CACHE_VERSION }}-${{ hashFiles('**/CMakeLists.txt', 'cmake/**', 'modules/**', 'plugins/**', 'thirdparty/**') }}
-        cache-restore-keys: |
-          ${{ runner.os }}-ccache-${{ matrix.configure_preset }}-${{ matrix.build_preset }}-${{ env.CACHE_VERSION }}-
-          ${{ runner.os }}-ccache-${{ matrix.configure_preset }}-${{ env.CACHE_VERSION }}-
-          ${{ runner.os }}-ccache-${{ env.CACHE_VERSION }}-
+      - name: Build (Linux)
+        # Configure and build using presets, then run tests.
+        if: runner.os == 'Linux'
+        run: |
+          set -e
+          cmake --preset "${{ matrix.configure_preset }}"
+          cmake --build --preset "${{ matrix.build_preset }}"
+          ctest --preset "${{ matrix.test_preset }}"
 
-    - name: Setup (Linux, no cache)
-      # Install Linux dependencies without caching.
-      if: runner.os == 'Linux' && !inputs.use-cache
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y xorg-dev libwayland-dev libxkbcommon-dev
-        echo "Linux setup complete; full builds run without caching."
+      - name: Cleanup (Windows)
+        # Confirm Windows cleanup is complete.
+        if: runner.os == 'Windows'
+        run: echo "Windows cleanup complete."
 
-    # Uncomment and modify as needed when we need to debug repo contents
-    # - name: Debug repo contents
-    #   run: |
-    #     git submodule status || true
-    #     ls -la
-    #     ls -la Plugins || true
-    #     ls -la Plugins/Toybox-OpenGL-Rendering-Plugin || true
-    #     ls -la Plugins/Toybox-SDL-Input-Plugin || true
-
-    - name: Build (Windows)
-      # Configure and build using presets, then run tests.
-      if: runner.os == 'Windows'
-      shell: bash
-      run: |
-        set -e
-        launcher_args=()
-        if [ -n "${{ matrix.compiler_launcher }}" ]; then
-          launcher_args+=("-D" "CMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.compiler_launcher }}")
-          launcher_args+=("-D" "CMAKE_C_COMPILER_LAUNCHER=${{ matrix.compiler_launcher }}")
-        fi
-        cmake --preset "${{ matrix.configure_preset }}" "${launcher_args[@]}"
-        cmake --build --preset "${{ matrix.build_preset }}"
-        ctest --preset "${{ matrix.test_preset }}"
-
-    - name: Build (Linux)
-      # Configure and build using presets, then run tests.
-      if: runner.os == 'Linux'
-      run: |
-        set -e
-        launcher_args=()
-        if [ -n "${{ matrix.compiler_launcher }}" ]; then
-          launcher_args+=("-D" "CMAKE_CXX_COMPILER_LAUNCHER=${{ matrix.compiler_launcher }}")
-          launcher_args+=("-D" "CMAKE_C_COMPILER_LAUNCHER=${{ matrix.compiler_launcher }}")
-        fi
-        cmake --preset "${{ matrix.configure_preset }}" "${launcher_args[@]}"
-        cmake --build --preset "${{ matrix.build_preset }}"
-        ctest --preset "${{ matrix.test_preset }}"
-
-    - name: Cleanup (Windows)
-      # Confirm Windows cleanup is complete.
-      if: runner.os == 'Windows'
-      run: echo "Windows cleanup complete."
-
-    - name: Cleanup (Linux)
-      # Confirm Linux cleanup is complete.
-      if: runner.os == 'Linux'
-      run: echo "Linux cleanup complete."
+      - name: Cleanup (Linux)
+        # Confirm Linux cleanup is complete.
+        if: runner.os == 'Linux'
+        run: echo "Linux cleanup complete."


### PR DESCRIPTION
### Motivation

- Remove GitHub Actions caches and the fast/full build split to simplify CI and avoid cache-induced variance. 
- Ensure CI stops early on the first matrix failure so feedback is faster. 
- Reduce CI surface area and maintenance by collapsing multiple jobs into a single, predictable path.

### Description

- Removed cache-related inputs and environment variables from the reusable workflow in `.github/workflows/cmake-platform-build.yml`, including `use-cache`, `CACHE_VERSION`, and `SCCACHE_DIR`.
- Eliminated cache setup steps and composite actions that used `actions/cache@v4` by removing uses of `./.github/actions/windows-setup` and `./.github/actions/linux-setup` and their cache wiring.
- Hardcoded matrix behavior to `strategy.fail-fast: true` and removed the `fail-fast` input so matrix runs stop on the first failure.
- Simplified the top-level workflow `.github/workflows/cmake-multi-platform.yml` by collapsing `build_fast` / `cache_seed` / `build_full` into a single `build` job and removed `compiler_launcher` matrix entries and cache-dependent launcher wiring from configure/build commands.

### Testing

- Ran `git diff --check` which produced no whitespace or patch errors and succeeded.
- Attempted YAML validation via a Python `yaml.safe_load` check but it failed because `PyYAML` is not installed in the environment, so full YAML parsing could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c769a6cb5883279681de60f0ceca9a)