### PR TITLE
Add CodeStandard and AGENTS update; apply broad header reformatting and small API tidy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,74 +1,24 @@
-# Toybox Agent Standards
+# Toybox Agent Guide
 
-## Language & Feature Use
+This file defines contributor workflow rules for agents working in `/workspace/Toybox`.
 
-- The project targets C++23.
-- Prefer copy-style initialization (`int value = {};`, `auto widget = Widget(args);`) over brace-only or direct-call
-  forms (`int value{};`, `auto widget(Widget(args));`) to keep intent obvious.
-- Avoid forward declarations where possible, prefer directly including what is needed.
-- Never use blanket namespace imports (for example, `using namespace tbx;`); always qualify symbols explicitly with
-  their namespace (for example, `tbx::Plugin`).
+## Primary coding standard
+- Follow `CodeStandard.md` for all C++ style, formatting, class layout, and documentation expectations.
 
-## Formatting & Layout
+## Agent workflow
+- Follow DRY principles; avoid duplicated logic and duplicated data transformations.
+- Do not remake the wheel; reuse existing engine utilities/components before introducing new implementations.
+- When it makes sense, design features and helpers for reusability.
+- Keep changes focused and minimal to the requested scope.
+- Prefer direct includes over forward declarations.
+- Do not use `using namespace ...`.
+- Remove stale/unused declarations and definitions instead of leaving placeholders.
+- Keep message/command logic in `.cpp` files when applicable.
+- Run relevant tests/build checks for touched areas when practical.
+- In final summaries, list what was validated and call out any gaps.
 
-- Follow the root `.clang-format` (Allman braces, Microsoft base, 4-space indents, column limit 100, namespace
-  indentation, sorted includes). Run the formatter on any touched file or match its style manually.
-- Use linux style line endings: `LF`.
-- Keep `#include` directives contiguous—no blank lines between include statements.
-- Keep namespaces non-empty AKA avoid anonymous namespaces and detail namespaces, just put util methods as static
-  methods in the root namespace. If you only need a translation-unit helper, prefer `static` functions or unnamed
-  structs empty over empty or detail namespaces.
-- Maintain include hygiene: headers should only include what they use, and source files should provide the heavier
-  dependencies.
-- Don't use forward declarations where possible, directly include what is needed.
-- Simplify and remove nesting where possible.
-- Don't nest structs/classes and don't make massive header files, break things up so the project stays organized and
-  things are easy to find.
-- Prefer to not use curly braces for single line ifs, for, and while loops.
-- Prefer designated initialization when available.
-
-## Naming & API Shape
-
-- Choose descriptive, self-documenting names; avoid jargon, abbreviations, or `util`-style catch‑all names.
-- Use `get...`/`set...` prefixes for accessors and mutators to keep intent explicit and question style names for bool
-  returns.
-- methods that have an optional out with a bool return should have a `try` prefix.
-- Prefer concrete verb phrases for commands/events (e.g., `CreateWindowCommand`), mirroring the existing messaging
-  vocabulary.
-
-## Documentation Expectations
-
-- Use the following exact Doxygen summary structure for public API docs:
-  ```
-  /// @brief
-  /// Purpose: ...
-  /// @details
-  /// Ownership: ...
-  /// Thread Safety: ...
-  ```
-- Do not add summary/documentation comments for constructors, destructors, copy constructors, move constructors, or assignment operators unless there is unusual ownership/threading behavior that truly needs explicit clarification.
-- Every public API (classes, structs, functions, free helpers, message types) must be documented using Doxygen format with:
-    1. **Purpose** – what the API does.
-    2. **Ownership** – who owns returned or stored resources and lifetime notes (e.g., non-owning pointers, reference expectations).
-    3. **Thread Safety** – whether callers can use it concurrently, and any required synchronization.
-- Keep doc comments adjacent to declarations; brief inline notes are acceptable for complex implementation details.
-- Complex and long methods should be broken up with comments explaining things, and preferably if really large, they should be broken up into sub methods that are then documented with summaries and meaningful names.
-
-## Memory & Handle Management
-
-- Use references over pointers when object is guaranteed to be valid for the usage of the ref.
-- Prefer smart pointers whenever ownership semantics are needed. Only fall back to raw pointers for non-owning references that are trivially validated elsewhere.
-- When referencing engine objects without ownership, document the expectation and lifetime contract.
-
-## Miscellaneous Practices
-
-- Keep translation units free of unused declarations or definitions; delete stale code rather than leaving empty shells.
-- Ensure commands/events and other message types have their logic defined in `.cpp` files to keep headers lightweight.
-- Validate changes with the relevant tests or builds when practical, and mention what was (or was not) run in your final
-  summary.
-- Tests must not touch disk; prefer source or in-memory APIs.
-- Use AAA (Arrange, Act, Assert) structure in tests with labeled sections.
-- Document what each test validates (summary comment or concise inline note).
-- Aim to cover all public APIs with tests; call out gaps when constraints prevent coverage.
-
-By aligning with these standards, we keep the Toybox Engine consistent, readable, and predictable for every contributor.
+## Testing guidance
+- Tests must not use filesystem or network I/O.
+- Tests must use mocks/fakes/stubs for all filesystem and network behavior.
+- Use Arrange / Act / Assert structure.
+- Add concise comments only when they clarify non-obvious behavior.

--- a/CodeStandard.md
+++ b/CodeStandard.md
@@ -1,0 +1,70 @@
+# Toybox CodeStandard
+
+## Language
+- Target C++23.
+- Do not use C++ attributes (for example `[[nodiscard]]`).
+- Do not use `explicit` on constructors.
+- Prefer copy-style initialization.
+- Do not use blanket namespace imports.
+
+## Documentation
+- Use Doxygen `///` summaries only for:
+  - `struct` declarations.
+  - `class` declarations.
+  - Public methods.
+- Simple properties may use `//` comments when helpful.
+- Do not add documentation comments to private members.
+- Remove unnecessary comments and summaries.
+- Keep Doxygen summaries directly adjacent to their declaration (no blank line between summary and declaration).
+- Plugin and example lifecycle methods (`attach`, `detach`, `update`, including `on_attach`, `on_detach`, `on_update`, `on_fixed_update`) do not require Doxygen summaries.
+
+## Class / Struct Layout
+Use this ordering for every class/struct:
+
+```cpp
+class/struct Name :
+    InheritFromA,
+    InheritFromB
+{
+  public:
+    Usings...
+
+  public:
+    Constructor
+    Destructor
+
+  public:
+    CopyConstructors...
+    AssignmentOperators...
+
+  public:
+    Methods (sort by keyword: static/inline/etc, then by name)
+
+  public:
+    Properties (sort by keyword: static/inline/etc, then by name)
+
+  private:
+    Constructor
+    Destructor
+
+  private:
+    CopyConstructors...
+    AssignmentOperators...
+
+  private:
+    Methods (sort by keyword: static/inline/etc, then by name)
+
+  private:
+    Properties (sort by keyword: static/inline/etc, then by name)
+};
+```
+
+## Type Organization
+- Do not nest classes or structs inside other classes/structs.
+- Move nested helper types to top-level declarations within the same namespace.
+
+## Formatting
+- Follow root `.clang-format`.
+- Use LF line endings.
+- Keep `#include` directives contiguous.
+- Prefer simple, flat control flow and remove unnecessary nesting.

--- a/examples/2d_example/runtime/src/runtime.h
+++ b/examples/2d_example/runtime/src/runtime.h
@@ -8,33 +8,11 @@ namespace two_d_example
     /// @details
     /// Ownership: Owned by the plugin host; stores no owning references to host-managed systems.
     /// Thread Safety: Not thread-safe; the host invokes lifecycle callbacks on the main thread.
-
     class TwoDExampleRuntimePlugin final : public tbx::Plugin
     {
       public:
-        /// @brief
-        /// Purpose: Creates the example camera and renderable entities when the plugin attaches.
-        /// @details
-        /// Ownership: Does not retain ownership of the provided host; only uses it during the call
-        /// and through the base host reference.
-        /// Thread Safety: Not thread-safe; call from the main thread during plugin attachment.
-
         void on_attach(tbx::IPluginHost& host) override;
-
-        /// @brief
-        /// Purpose: Resets runtime-only animation state before the plugin detaches.
-        /// @details
-        /// Ownership: Does not own external resources.
-        /// Thread Safety: Not thread-safe; call from the main thread during plugin detachment.
-
         void on_detach() override;
-
-        /// @brief
-        /// Purpose: Advances the example animation and updates entity transforms and colors.
-        /// @details
-        /// Ownership: Uses host-owned entities and components without taking ownership.
-        /// Thread Safety: Not thread-safe; call from the main thread once per frame.
-
         void on_update(const tbx::DeltaTime& dt) override;
 
       private:

--- a/modules/app/include/tbx/app/app_settings.h
+++ b/modules/app/include/tbx/app/app_settings.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all stored path values.
     /// Thread Safety: Not thread-safe; synchronize access externally.
-
     struct TBX_API PathSettings
     {
         std::filesystem::path working_directory = {};
@@ -24,7 +23,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all stored settings values.
     /// Thread Safety: Not thread-safe; synchronize access externally.
-
     struct TBX_API AppSettings
     {
         AppSettings(

--- a/modules/app/include/tbx/app/application.h
+++ b/modules/app/include/tbx/app/application.h
@@ -25,7 +25,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of application resources.
         /// Thread Safety: Not thread-safe; call from the main thread.
-
         int run();
 
         /// @brief
@@ -33,7 +32,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         const std::string& get_name() const override;
 
         /// @brief
@@ -41,7 +39,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         const Handle& get_icon_handle() const override;
 
         /// @brief
@@ -49,7 +46,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         AppSettings& get_settings() override;
 
         /// @brief
@@ -57,7 +53,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         IMessageCoordinator& get_message_coordinator() override;
 
         /// @brief
@@ -65,7 +60,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         EntityRegistry& get_entity_registry() override;
 
         /// @brief
@@ -73,7 +67,6 @@ namespace tbx
         /// @details
         /// Ownership: The application retains ownership; callers receive a reference.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         AssetManager& get_asset_manager() override;
 
         /// @brief
@@ -81,7 +74,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Thread-safe according to JobSystem guarantees.
-
         JobSystem& get_job_system() override;
 
         /// @brief
@@ -89,7 +81,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Thread-safe according to ThreadManager guarantees.
-
         ThreadManager& get_thread_manager() override;
 
         /// @brief
@@ -97,7 +88,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the application.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         InputManager& get_input_manager() override;
 
       private:

--- a/modules/assets/include/tbx/assets/asset_handle_serializer.h
+++ b/modules/assets/include/tbx/assets/asset_handle_serializer.h
@@ -14,7 +14,6 @@ namespace tbx
     /// Ownership: Returns owned Handle instances to callers and does not retain file resources.
     /// Thread Safety: Implementations are safe for concurrent use when injected file services are
     /// thread-safe.
-
     class TBX_API IAssetHandleSerializer
     {
       public:
@@ -26,7 +25,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns an owning unique_ptr to a Handle on success.
         /// Thread Safety: Safe when filesystem services used by the implementation are thread-safe.
-
         virtual std::unique_ptr<Handle> read_from_disk(
             const std::filesystem::path& working_directory,
             const std::filesystem::path& asset_path) const = 0;
@@ -36,7 +34,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns an owning unique_ptr to a Handle on success.
         /// Thread Safety: Safe when file_ops is thread-safe.
-
         virtual std::unique_ptr<Handle> read_from_disk(
             const IFileOps& file_ops,
             const std::filesystem::path& asset_path) const = 0;
@@ -46,7 +43,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns an owning unique_ptr to a Handle on success.
         /// Thread Safety: Safe to call concurrently.
-
         virtual std::unique_ptr<Handle> read_from_source(
             std::string_view meta_text,
             const std::filesystem::path& asset_path) const = 0;
@@ -56,7 +52,6 @@ namespace tbx
         /// @details
         /// Ownership: Performs a read-modify-write and does not retain file contents.
         /// Thread Safety: Safe when filesystem services used by the implementation are thread-safe.
-
         virtual bool try_write_to_disk(
             const std::filesystem::path& working_directory,
             const std::filesystem::path& asset_path,
@@ -67,7 +62,6 @@ namespace tbx
         /// @details
         /// Ownership: Performs a read-modify-write and does not retain file contents.
         /// Thread Safety: Safe when file_ops is thread-safe.
-
         virtual bool try_write_to_disk(
             IFileOps& file_ops,
             const std::filesystem::path& asset_path,
@@ -79,7 +73,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns owned Handle values and does not retain file content across calls.
     /// Thread Safety: Safe to call concurrently when file services are thread-safe.
-
     class TBX_API AssetHandleSerializer final : public IAssetHandleSerializer
     {
       public:

--- a/modules/assets/include/tbx/assets/asset_loaders.h
+++ b/modules/assets/include/tbx/assets/asset_loaders.h
@@ -13,7 +13,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns AssetPromise or shared asset pointers owned by the caller.
     /// Thread Safety: Safe to call concurrently; delegates to thread-safe loaders.
-
     template <typename TAsset>
     struct AssetLoader
     {
@@ -35,7 +34,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership with the caller.
     /// Thread Safety: Safe to call concurrently.
-
     template <>
     struct AssetLoader<Model>
     {
@@ -55,7 +53,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership with the caller.
     /// Thread Safety: Safe to call concurrently.
-
     template <>
     struct AssetLoader<Texture>
     {
@@ -87,7 +84,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership with the caller.
     /// Thread Safety: Safe to call concurrently.
-
     template <>
     struct AssetLoader<AudioClip>
     {
@@ -107,7 +103,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership with the caller.
     /// Thread Safety: Safe to call concurrently.
-
     template <>
     struct AssetLoader<Shader>
     {
@@ -127,7 +122,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership with the caller.
     /// Thread Safety: Safe to call concurrently.
-
     template <>
     struct AssetLoader<Material>
     {

--- a/modules/assets/include/tbx/assets/asset_manager.h
+++ b/modules/assets/include/tbx/assets/asset_manager.h
@@ -25,7 +25,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not own any resources.
     /// Thread Safety: Safe to copy between threads.
-
     enum class AssetStreamState
     {
         UNLOADED,
@@ -38,7 +37,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not own any resources.
     /// Thread Safety: Safe to copy between threads.
-
     struct AssetUsage
     {
         uint ref_count = 0U;
@@ -52,7 +50,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type settings owned by the caller.
     /// Thread Safety: Safe to copy between threads.
-
     struct TextureLoadParameters
     {
         TextureSettings settings = {};
@@ -63,7 +60,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct ModelLoadParameters
     {
     };
@@ -73,7 +69,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct ShaderLoadParameters
     {
     };
@@ -83,7 +78,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct MaterialLoadParameters
     {
     };
@@ -93,7 +87,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct AudioLoadParameters
     {
     };
@@ -103,7 +96,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores path copies owned by the record.
     /// Thread Safety: Safe to copy between threads.
-
     struct NormalizedAssetPath
     {
         std::filesystem::path resolved_path;
@@ -116,7 +108,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores path copies owned by the registry.
     /// Thread Safety: Safe to copy between threads.
-
     struct AssetRegistryEntry
     {
         std::filesystem::path resolved_path;
@@ -130,7 +121,6 @@ namespace tbx
     /// @details
     /// Ownership: Implementations own their tracked asset records.
     /// Thread Safety: Requires external synchronization by AssetManager.
-
     struct IAssetStore
     {
         virtual ~IAssetStore() = default;
@@ -143,7 +133,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the shared asset instance and load promise.
     /// Thread Safety: Requires external synchronization by AssetManager.
-
     template <typename TAsset>
     struct AssetRecord
     {
@@ -163,7 +152,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns AssetRecord instances for its asset type.
     /// Thread Safety: Requires external synchronization by AssetManager.
-
     template <typename TAsset>
     struct AssetStore final : IAssetStore
     {
@@ -196,12 +184,24 @@ namespace tbx
         }
     };
 
+    enum class AssetMetaState
+    {
+        VALID,
+        MISSING,
+        INVALID
+    };
+
+    struct ResolvedAssetMetaId
+    {
+        Uuid resolved_id = {};
+        AssetMetaState state = AssetMetaState::MISSING;
+    };
+
     /// @brief
     /// Purpose: Tracks streamed assets by normalized path and maintains usage metadata.
     /// @details
     /// Ownership: Owns shared asset instances for loaded assets and releases them when streamed
     /// out. Thread Safety: All public member functions are synchronized internally.
-
     class TBX_API AssetManager final
     {
       public:
@@ -210,9 +210,8 @@ namespace tbx
         /// @details
         /// Ownership: The manager stores a copy of the callable.
         /// Thread Safety: The callable must be safe to invoke concurrently.
-
         using HandleSource = std::function<bool(const std::filesystem::path&, Handle& out_handle)>;
-        explicit AssetManager(
+        AssetManager(
             std::filesystem::path working_directory,
             std::vector<std::filesystem::path> asset_directories = {},
             HandleSource handle_source = {},
@@ -229,7 +228,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared asset instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         template <typename TAsset>
         std::shared_ptr<TAsset> load(const Handle& handle)
         {
@@ -272,7 +270,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared texture instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::shared_ptr<Texture> load(
             const Handle& handle,
             const TextureLoadParameters& parameters);
@@ -282,7 +279,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared model instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::shared_ptr<Model> load(const Handle& handle, const ModelLoadParameters&)
         {
             return load<Model>(handle);
@@ -293,7 +289,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared shader instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::shared_ptr<Shader> load(const Handle& handle, const ShaderLoadParameters&)
         {
             return load<Shader>(handle);
@@ -304,7 +299,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared material instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::shared_ptr<Material> load(const Handle& handle, const MaterialLoadParameters&)
         {
             return load<Material>(handle);
@@ -315,7 +309,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a shared audio instance owned jointly by the manager and caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::shared_ptr<AudioClip> load(const Handle& handle, const AudioLoadParameters&)
         {
             return load<AudioClip>(handle);
@@ -326,7 +319,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns caller-owned usage data by value.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         template <typename TAsset>
         AssetUsage get_usage(const Handle& handle) const
         {
@@ -350,7 +342,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a UUID value; no ownership transfer.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         Uuid resolve_asset_id(const Handle& handle);
 
         /// @brief
@@ -358,7 +349,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a path value owned by the caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::filesystem::path resolve_asset_path(const std::filesystem::path& asset_path) const;
 
         /// @brief
@@ -366,7 +356,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a path value owned by the caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::filesystem::path resolve_asset_path(const Handle& handle) const;
 
         /// @brief
@@ -374,7 +363,6 @@ namespace tbx
         /// @details
         /// Ownership: Copies the provided path into internal storage.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         void add_asset_directory(const std::filesystem::path& path);
 
         /// @brief
@@ -382,7 +370,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a copy; callers own the returned paths.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         std::vector<std::filesystem::path> get_asset_directories() const;
 
         /// @brief
@@ -390,7 +377,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns an AssetPromise that shares ownership with the caller.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         template <typename TAsset>
         AssetPromise<TAsset> load_async(const Handle& handle)
         {
@@ -433,7 +419,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases the manager-owned asset instance when streaming out.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         template <typename TAsset>
         bool unload(const Handle& handle, bool force = false)
         {
@@ -467,7 +452,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases manager-owned asset instances that are safe to evict.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         void unload_all();
 
         /// @brief
@@ -475,7 +459,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases manager-owned asset instances that are safe to evict.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         void unload_unreferenced();
 
         /// @brief
@@ -483,7 +466,6 @@ namespace tbx
         /// @details
         /// Ownership: Replaces the manager-owned asset instance with the newly loaded instance.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         template <typename TAsset>
         bool reload(const Handle& handle)
         {
@@ -524,23 +506,9 @@ namespace tbx
         /// @details
         /// Ownership: Retains manager ownership of the asset instance while pinned.
         /// Thread Safety: Safe to call concurrently; internal state is synchronized.
-
         void set_pinned(const Handle& handle, bool is_pinned);
 
       private:
-        enum class AssetMetaState
-        {
-            VALID,
-            MISSING,
-            INVALID
-        };
-
-        struct ResolvedAssetMetaId
-        {
-            Uuid resolved_id = {};
-            AssetMetaState state = AssetMetaState::MISSING;
-        };
-
         void discover_assets();
 
         NormalizedAssetPath normalize_path(const std::filesystem::path& asset_path) const

--- a/modules/assets/include/tbx/assets/assets.h
+++ b/modules/assets/include/tbx/assets/assets.h
@@ -15,7 +15,6 @@ namespace tbx
     /// Ownership: The asset data is shared between the caller and the asset system. The promise is
     /// shared and can be waited on by multiple callers. Thread Safety: Safe to copy between
     /// threads; coordinate asset mutation externally.
-
     template <typename TAsset>
     struct AssetPromise
     {
@@ -28,7 +27,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not transfer ownership.
     /// Thread Safety: Safe to call concurrently.
-
     TBX_API void warn_missing_dispatcher(std::string_view action);
 
     /// @brief
@@ -36,6 +34,5 @@ namespace tbx
     /// @details
     /// Ownership: The returned future owns its shared state and completes with a failed Result.
     /// Thread Safety: Safe to call concurrently.
-
     TBX_API std::shared_future<Result> make_missing_dispatcher_future(std::string_view action);
 }

--- a/modules/assets/include/tbx/assets/audio_assets.h
+++ b/modules/assets/include/tbx/assets/audio_assets.h
@@ -13,7 +13,6 @@ namespace tbx
     /// Ownership: Returns an AssetPromise that shares ownership of the audio data with the caller.
     /// The payload is destroyed when the final shared reference is released. Thread Safety: Safe to
     /// call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API AssetPromise<AudioClip> load_audio_async(const std::filesystem::path& asset_path);
 
     /// @brief
@@ -22,6 +21,5 @@ namespace tbx
     /// Ownership: Returns shared audio data owned by the caller. The payload is destroyed when the
     /// final shared reference is released. Thread Safety: Safe to call concurrently provided the
     /// global dispatcher is thread-safe.
-
     TBX_API std::shared_ptr<AudioClip> load_audio(const std::filesystem::path& asset_path);
 }

--- a/modules/assets/include/tbx/assets/material_assets.h
+++ b/modules/assets/include/tbx/assets/material_assets.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an AssetPromise that shares ownership of the material with the caller.
     /// Thread Safety: Safe to call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API AssetPromise<Material> load_material_async(const std::filesystem::path& asset_path);
 
     /// @brief
@@ -20,6 +19,5 @@ namespace tbx
     /// @details
     /// Ownership: Returns shared material data owned by the caller.
     /// Thread Safety: Safe to call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API std::shared_ptr<Material> load_material(const std::filesystem::path& asset_path);
 }

--- a/modules/assets/include/tbx/assets/messages.h
+++ b/modules/assets/include/tbx/assets/messages.h
@@ -17,7 +17,6 @@ namespace tbx
     /// @details
     /// Ownership: The asset pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     template <typename TAsset>
     struct LoadAssetRequest : public Request<void>
     {
@@ -38,7 +37,6 @@ namespace tbx
     /// @details
     /// Ownership: The texture asset pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     struct TBX_API LoadTextureRequest : public LoadAssetRequest<Texture>
     {
       public:
@@ -72,7 +70,6 @@ namespace tbx
     /// @details
     /// Ownership: The model pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     struct TBX_API LoadModelRequest : public LoadAssetRequest<Model>
     {
       public:
@@ -87,7 +84,6 @@ namespace tbx
     /// @details
     /// Ownership: The shader program pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     struct TBX_API LoadShaderRequest : public LoadAssetRequest<Shader>
     {
       public:
@@ -102,7 +98,6 @@ namespace tbx
     /// @details
     /// Ownership: The material pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     struct TBX_API LoadMaterialRequest : public LoadAssetRequest<Material>
     {
       public:
@@ -117,7 +112,6 @@ namespace tbx
     /// @details
     /// Ownership: The audio clip pointer is non-owning and owned by the caller.
     /// Thread Safety: Payload access requires external synchronization.
-
     struct TBX_API LoadAudioRequest : public LoadAssetRequest<AudioClip>
     {
       public:

--- a/modules/assets/include/tbx/assets/model_assets.h
+++ b/modules/assets/include/tbx/assets/model_assets.h
@@ -13,7 +13,6 @@ namespace tbx
     /// Ownership: Returns an AssetPromise that shares ownership of the model data with the caller.
     /// The payload is destroyed when the final shared reference is released. Thread Safety: Safe to
     /// call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API AssetPromise<Model> load_model_async(const std::filesystem::path& asset_path);
 
     /// @brief
@@ -22,6 +21,5 @@ namespace tbx
     /// Ownership: Returns shared model data owned by the caller. The payload is destroyed when the
     /// final shared reference is released. Thread Safety: Safe to call concurrently provided the
     /// global dispatcher is thread-safe.
-
     TBX_API std::shared_ptr<Model> load_model(const std::filesystem::path& asset_path);
 }

--- a/modules/assets/include/tbx/assets/shader_assets.h
+++ b/modules/assets/include/tbx/assets/shader_assets.h
@@ -13,7 +13,6 @@ namespace tbx
     /// Ownership: Returns an AssetPromise that shares ownership of the shader program with the
     /// caller. The payload is destroyed when the final shared reference is released. Thread Safety:
     /// Safe to call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API AssetPromise<Shader> load_shader_async(const std::filesystem::path& asset_path);
 
     /// @brief
@@ -22,6 +21,5 @@ namespace tbx
     /// Ownership: Returns shared shader program data owned by the caller. The payload is destroyed
     /// when the final shared reference is released. Thread Safety: Safe to call concurrently
     /// provided the global dispatcher is thread-safe.
-
     TBX_API std::shared_ptr<Shader> load_shader(const std::filesystem::path& asset_path);
 }

--- a/modules/assets/include/tbx/assets/texture_assets.h
+++ b/modules/assets/include/tbx/assets/texture_assets.h
@@ -13,7 +13,6 @@ namespace tbx
     /// Ownership: Returns an AssetPromise that shares ownership of the texture data with the
     /// caller. The payload is destroyed when the final shared reference is released. Thread Safety:
     /// Safe to call concurrently provided the global dispatcher is thread-safe.
-
     TBX_API AssetPromise<Texture> load_texture_async(
         const std::filesystem::path& asset_path,
         TextureWrap wrap,
@@ -28,7 +27,6 @@ namespace tbx
     /// Ownership: Returns shared texture data owned by the caller. The payload is destroyed when
     /// the final shared reference is released. Thread Safety: Safe to call concurrently provided
     /// the global dispatcher is thread-safe.
-
     TBX_API std::shared_ptr<Texture> load_texture(
         const std::filesystem::path& asset_path,
         TextureWrap wrap,

--- a/modules/assets/tests/asset_meta_tests.cpp
+++ b/modules/assets/tests/asset_meta_tests.cpp
@@ -8,7 +8,7 @@ namespace tbx::tests::assets
     class InMemoryFileOps final : public IFileOps
     {
       public:
-        explicit InMemoryFileOps(std::filesystem::path working_directory)
+        InMemoryFileOps(std::filesystem::path working_directory)
             : _working_directory(std::move(working_directory))
         {
         }

--- a/modules/async/include/tbx/async/async_settings.h
+++ b/modules/async/include/tbx/async/async_settings.h
@@ -9,7 +9,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type owned by callers and by AppSettings.
     /// Thread Safety: Safe for concurrent reads; synchronize concurrent writes externally.
-
     struct TBX_API AsyncSettings
     {
         JobSystemConfiguration job_system = {};

--- a/modules/async/include/tbx/async/job_system.h
+++ b/modules/async/include/tbx/async/job_system.h
@@ -19,7 +19,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type owned by callers and copied into the job system constructor.
     /// Thread Safety: Safe for concurrent use because it stores only plain data.
-
     struct TBX_API JobSystemConfiguration
     {
         std::size_t worker_count = {};
@@ -32,7 +31,6 @@ namespace tbx
     /// Thread Safety: `schedule`, `schedule_with_future`, `wait_for_idle`, `stop`, and
     /// `get_worker_count` are safe to call concurrently. Destruction must be externally
     /// synchronized against concurrent use.
-
     class TBX_API JobSystem
     {
       public:
@@ -50,7 +48,6 @@ namespace tbx
         /// @details
         /// Ownership: Transfers ownership of the job callable into the scheduler queue.
         /// Thread Safety: Thread-safe. Throws if scheduling is attempted after `stop`.
-
         void schedule(Job&& job);
 
         /// @brief
@@ -59,7 +56,6 @@ namespace tbx
         /// Ownership: Transfers the callable into the scheduler. Returned future is owned by the
         /// caller and stores result/exception state. Thread Safety: Thread-safe. Throws if
         /// scheduling is attempted after `stop`.
-
         template <typename TCallable, typename... TArgs>
             requires std::invocable<TCallable, TArgs...>
         auto schedule_with_future(TCallable&& callable, TArgs&&... args)
@@ -85,7 +81,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership.
         /// Thread Safety: Thread-safe.
-
         void wait_for_idle();
 
         /// @brief
@@ -93,7 +88,6 @@ namespace tbx
         /// @details
         /// Ownership: Retains queued job ownership until they are drained, then releases all worker
         /// ownership. Thread Safety: Thread-safe and idempotent.
-
         void stop();
 
         /// @brief
@@ -101,7 +95,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a value copy.
         /// Thread Safety: Thread-safe.
-
         std::size_t get_worker_count() const;
 
       private:

--- a/modules/async/include/tbx/async/thread_manager.h
+++ b/modules/async/include/tbx/async/thread_manager.h
@@ -23,7 +23,6 @@ namespace tbx
     /// Ownership: Owns all registered lane threads and queued tasks for the manager lifetime.
     /// Thread Safety: `try_create_lane`, `has_lane`, `post`, `post_with_future`, `stop_lane`,
     /// `stop_all`, and `get_lane_count` are thread-safe.
-
     class TBX_API ThreadManager final
     {
       public:
@@ -41,7 +40,6 @@ namespace tbx
         /// @details
         /// Ownership: Manager owns the created lane and its worker thread.
         /// Thread Safety: Thread-safe.
-
         bool try_create_lane(std::string_view lane_name);
 
         /// @brief
@@ -49,7 +47,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns value only; no ownership transfer.
         /// Thread Safety: Thread-safe.
-
         bool has_lane(std::string_view lane_name) const;
 
         /// @brief
@@ -57,7 +54,6 @@ namespace tbx
         /// @details
         /// Ownership: Transfers task ownership to the target lane queue.
         /// Thread Safety: Thread-safe. Throws when lane is missing or stopped.
-
         void post(std::string_view lane_name, Task&& task);
 
         /// @brief
@@ -65,7 +61,6 @@ namespace tbx
         /// @details
         /// Ownership: Callable ownership is transferred to the lane queue; returned future is owned
         /// by the caller. Thread Safety: Thread-safe. Throws when lane is missing or stopped.
-
         template <typename TCallable, typename... TArgs>
             requires std::invocable<TCallable, TArgs...>
         auto post_with_future(std::string_view lane_name, TCallable&& callable, TArgs&&... args)
@@ -92,7 +87,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases ownership of the removed lane and drains queued work.
         /// Thread Safety: Thread-safe. No-op when lane does not exist.
-
         void stop_lane(std::string_view lane_name);
 
         /// @brief
@@ -100,7 +94,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases ownership of all lanes and drains queued work.
         /// Thread Safety: Thread-safe and idempotent.
-
         void stop_all();
 
         /// @brief
@@ -108,14 +101,13 @@ namespace tbx
         /// @details
         /// Ownership: Returns value only; no ownership transfer.
         /// Thread Safety: Thread-safe.
-
         std::size_t get_lane_count() const;
 
       private:
         class ThreadLane final
         {
           public:
-            explicit ThreadLane(std::string lane_name);
+            ThreadLane(std::string lane_name);
             ~ThreadLane() noexcept;
 
             ThreadLane(const ThreadLane&) = delete;

--- a/modules/audio/include/tbx/audio/audio_clip.h
+++ b/modules/audio/include/tbx/audio/audio_clip.h
@@ -10,7 +10,6 @@ namespace tbx
     /// @details
     /// Ownership: Instances own their sample buffers.
     /// Thread Safety: Safe to move across threads; synchronize shared mutation externally.
-
     struct TBX_API AudioClip
     {
         uint32 sample_rate = 44100;

--- a/modules/common/include/tbx/common/handle.h
+++ b/modules/common/include/tbx/common/handle.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores owned name strings and UUID values.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct Handle
     {
         Handle() = default;
@@ -32,7 +31,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership.
         /// Thread Safety: Safe to call concurrently.
-
         bool is_valid() const
         {
             return id.is_valid();

--- a/modules/common/include/tbx/common/pipeline.h
+++ b/modules/common/include/tbx/common/pipeline.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Pipeline operations own their internal state and are held by unique ownership.
     /// Thread Safety: Not thread-safe; callers must synchronize access.
-
     class TBX_API PipelineOperation
     {
       public:
@@ -22,7 +21,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of referenced resources.
         /// Thread Safety: Not thread-safe; call from the owning thread.
-
         virtual void execute(const std::any& payload) = 0;
 
         /// @brief
@@ -30,7 +28,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of referenced resources.
         /// Thread Safety: Not thread-safe; call from the owning thread.
-
         void execute()
         {
             execute(std::any {});
@@ -42,7 +39,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the operations via unique pointers.
     /// Thread Safety: Not thread-safe; synchronize when used across threads.
-
     class TBX_API Pipeline : public PipelineOperation
     {
       public:
@@ -57,7 +53,6 @@ namespace tbx
         /// @details
         /// Ownership: Takes unique ownership of the operation.
         /// Thread Safety: Not thread-safe; callers must synchronize.
-
         void add_operation(std::unique_ptr<PipelineOperation> operation);
 
         /// @brief
@@ -65,7 +60,6 @@ namespace tbx
         /// @details
         /// Ownership: Releases unique ownership of stored operations.
         /// Thread Safety: Not thread-safe; callers must synchronize.
-
         void clear_operations();
 
         /// @brief
@@ -73,7 +67,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a non-owning reference to the stored operations.
         /// Thread Safety: Not thread-safe; callers must synchronize.
-
         const std::vector<std::unique_ptr<PipelineOperation>>& get_operations() const;
 
         /// @brief
@@ -81,7 +74,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of operations or payload resources.
         /// Thread Safety: Not thread-safe; call from the owning thread.
-
         void execute(const std::any& payload) override;
 
         /// @brief
@@ -89,7 +81,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of operations.
         /// Thread Safety: Not thread-safe; call from the owning thread.
-
         void execute();
 
       private:

--- a/modules/common/include/tbx/common/uuid.h
+++ b/modules/common/include/tbx/common/uuid.h
@@ -19,7 +19,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a value type; no ownership transfer.
         /// Thread Safety: Safe to call concurrently.
-
         TBX_API static Uuid combine(Uuid base, uint32 value);
 
         /// @brief
@@ -27,7 +26,6 @@ namespace tbx
         /// @details
         /// Ownership: Mutates this UUID in place.
         /// Thread Safety: Not thread-safe; synchronize mutation externally.
-
         TBX_API void combine(uint32 value);
 
         TBX_API bool is_valid() const;

--- a/modules/common/include/tbx/tbx_api.h
+++ b/modules/common/include/tbx/tbx_api.h
@@ -6,13 +6,11 @@
         /// @brief
         /// This macro is used to export functions and classes from a DLL.
         /// You want this macro defined when you are creating a DLL.
-
             #define TBX_API __declspec(dllexport)
         #else
         /// @brief
         /// This macro is used to import functions and classes from a DLL.
         /// If you are expecting export functionality ensure the TOOLBOX macro is defined.
-
             #define TBX_API __declspec(dllimport)
         #endif
     #else

--- a/modules/ecs/include/tbx/ecs/entity.h
+++ b/modules/ecs/include/tbx/ecs/entity.h
@@ -13,7 +13,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not own the registry; caller ensures registry lifetime exceeds this
     /// instance. Thread Safety: Not thread-safe; synchronize external concurrent access.
-
     class TBX_API Entity
     {
       public:
@@ -46,7 +45,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes a non-owning entity handle into out_parent when available.
         /// Thread Safety: Not thread-safe; synchronize external concurrent access.
-
         bool try_get_parent_entity(Entity& out_parent) const;
 
         template <typename TComponent>
@@ -79,7 +77,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an owned std::string.
     /// Thread Safety: Safe for concurrent use when the entity metadata is not being mutated.
-
     TBX_API std::string to_string(const Entity& entity);
 
     /// @brief
@@ -88,7 +85,6 @@ namespace tbx
     /// Ownership: Returns an owned Transform value snapshot.
     /// Thread Safety: Not thread-safe; synchronize external concurrent access. Notes: Entity
     /// Transform components are authored and stored in local space.
-
     TBX_API Transform get_world_space_transform(const Entity& entity);
 
     /// @brief
@@ -96,7 +92,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the contained Entity value only; does not own registry state.
     /// Thread Safety: Not thread-safe; synchronize external concurrent access.
-
     class TBX_API EntityScope
     {
       public:

--- a/modules/ecs/include/tbx/ecs/entity_registry.h
+++ b/modules/ecs/include/tbx/ecs/entity_registry.h
@@ -17,7 +17,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the underlying entt registry instance.
     /// Thread Safety: Not thread-safe; synchronize external concurrent access.
-
     class TBX_API EntityRegistry
     {
       public:
@@ -32,7 +31,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership; inspects registry-owned entity state only.
         /// Thread Safety: Not thread-safe; synchronize external concurrent access.
-
         bool has(const Uuid& id) const;
 
         template <typename TComponent>

--- a/modules/files/include/tbx/files/file_ops.h
+++ b/modules/files/include/tbx/files/file_ops.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Not applicable; this is a value-type classification.
     /// Thread Safety: Safe to copy between threads.
-
     enum class FileType
     {
         NONE,
@@ -26,7 +25,6 @@ namespace tbx
     /// @details
     /// Ownership: Not applicable; this is a value-type classification.
     /// Thread Safety: Safe to copy between threads.
-
     enum class FileDataFormat
     {
         BINARY,
@@ -39,7 +37,6 @@ namespace tbx
     /// Ownership: Implementations own any backing filesystem state they require.
     /// Thread Safety: Callers may use concurrently only when the concrete implementation supports
     /// it.
-
     class TBX_API IFileOps
     {
       public:
@@ -50,7 +47,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a copy owned by the caller.
         /// Thread Safety: Depends on the implementation.
-
         virtual std::filesystem::path get_working_directory() const = 0;
 
         /// @brief
@@ -58,7 +54,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a copy owned by the caller.
         /// Thread Safety: Depends on the implementation.
-
         virtual std::filesystem::path resolve(const std::filesystem::path& path) const = 0;
 
         /// @brief
@@ -66,7 +61,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to path.
         /// Thread Safety: Depends on the implementation.
-
         virtual bool exists(const std::filesystem::path& path) const = 0;
 
         /// @brief
@@ -74,7 +68,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a value type owned by the caller.
         /// Thread Safety: Depends on the implementation.
-
         virtual FileType get_type(const std::filesystem::path& path) const = 0;
 
         /// @brief
@@ -82,7 +75,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a caller-owned collection of paths.
         /// Thread Safety: Depends on the implementation.
-
         virtual std::vector<std::filesystem::path> read_directory(
             const std::filesystem::path& root) const = 0;
 
@@ -91,7 +83,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes into caller-owned storage.
         /// Thread Safety: Depends on the implementation.
-
         virtual bool read_file(
             const std::filesystem::path& path,
             FileDataFormat format,
@@ -102,7 +93,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references after returning.
         /// Thread Safety: Depends on the implementation.
-
         virtual bool write_file(
             const std::filesystem::path& path,
             FileDataFormat format,
@@ -114,18 +104,16 @@ namespace tbx
     /// @details
     /// Ownership: Owns its working directory value; does not own external resources.
     /// Thread Safety: Safe to call concurrently when the underlying filesystem APIs are safe.
-
     class TBX_API FileOperator final : public IFileOps
     {
       public:
-        explicit FileOperator(std::filesystem::path working_directory = {});
+        FileOperator(std::filesystem::path working_directory = {});
 
         /// @brief
         /// Purpose: Returns the working directory used for relative path resolution.
         /// @details
         /// Ownership: Returns a copy; callers own the returned path value.
         /// Thread Safety: Safe to call concurrently.
-
         std::filesystem::path get_working_directory() const override;
 
         /// @brief
@@ -133,7 +121,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a path value owned by the caller.
         /// Thread Safety: Safe to call concurrently.
-
         std::filesystem::path resolve(const std::filesystem::path& path) const override;
 
         /// @brief
@@ -141,7 +128,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to the provided path.
         /// Thread Safety: Safe to call concurrently.
-
         bool is_valid(const std::filesystem::path& path) const;
 
         /// @brief
@@ -149,7 +135,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to the provided path.
         /// Thread Safety: Safe to call concurrently.
-
         bool exists(const std::filesystem::path& path) const override;
 
         /// @brief
@@ -157,7 +142,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a value classification owned by the caller.
         /// Thread Safety: Safe to call concurrently.
-
         FileType get_type(const std::filesystem::path& path) const override;
 
         /// @brief
@@ -165,7 +149,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a caller-owned list of path values.
         /// Thread Safety: Safe to call concurrently.
-
         std::vector<std::filesystem::path> read_directory(
             const std::filesystem::path& root) const override;
 
@@ -175,7 +158,6 @@ namespace tbx
         /// Ownership: Does not retain references to the provided path.
         /// Thread Safety: Safe to call concurrently. Deduces a file when the path has an extension;
         /// otherwise a directory.
-
         bool create(const std::filesystem::path& path);
 
         /// @brief
@@ -183,7 +165,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes into the caller-owned output string.
         /// Thread Safety: Safe to call concurrently.
-
         bool read_file(const std::filesystem::path& path, FileDataFormat format, std::string& out)
             const override;
 
@@ -192,7 +173,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a caller-owned path value.
         /// Thread Safety: Not thread-safe; intended for one-time initialization.
-
         std::filesystem::path rotate(
             const std::filesystem::path& directory,
             std::string_view base_name,
@@ -204,7 +184,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain the provided data after the call returns.
         /// Thread Safety: Safe to call concurrently.
-
         bool write_file(
             const std::filesystem::path& path,
             FileDataFormat format,
@@ -215,7 +194,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to the provided path.
         /// Thread Safety: Safe to call concurrently.
-
         bool remove(const std::filesystem::path& path);
 
         /// @brief
@@ -223,7 +201,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to the provided paths.
         /// Thread Safety: Safe to call concurrently.
-
         bool rename(const std::filesystem::path& from, const std::filesystem::path& to);
 
         /// @brief
@@ -231,7 +208,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not retain references to the provided paths.
         /// Thread Safety: Safe to call concurrently.
-
         bool copy(const std::filesystem::path& from, const std::filesystem::path& to);
 
       private:

--- a/modules/graphics/include/tbx/graphics/graphics_settings.h
+++ b/modules/graphics/include/tbx/graphics/graphics_settings.h
@@ -13,7 +13,6 @@ namespace tbx
     /// Ownership: Enum values are copied by value by configuration systems.
     /// Thread Safety: Thread-safe as immutable enum constants; consuming settings remain externally
     /// synchronized.
-
     enum class RenderStage
     {
         FINAL_COLOR,
@@ -28,7 +27,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all setting values by value.
     /// Thread Safety: Not thread-safe; synchronize access externally.
-
     struct TBX_API GraphicsSettings
     {
         GraphicsSettings(
@@ -46,7 +44,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, bool> vsync_enabled;
 
         /// @brief
@@ -54,7 +51,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, GraphicsApi> graphics_api;
 
         /// @brief
@@ -62,7 +58,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, Size> resolution;
 
         /// @brief
@@ -70,7 +65,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, RenderStage> render_stage;
 
         /// @brief
@@ -78,7 +72,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, uint32> shadow_map_resolution;
 
         /// @brief
@@ -87,7 +80,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, float> shadow_render_distance;
 
         /// @brief
@@ -96,7 +88,6 @@ namespace tbx
         /// @details
         /// Ownership: Value owned by this settings object.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         Observable<GraphicsSettings, float> shadow_softness;
     };
 }

--- a/modules/graphics/include/tbx/graphics/light.h
+++ b/modules/graphics/include/tbx/graphics/light.h
@@ -10,7 +10,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type; callers own copies and manage component storage.
     /// Thread Safety: Safe to copy between threads; synchronize mutation externally.
-
     struct TBX_API Light
     {
         Light();
@@ -20,7 +19,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Color color = Color(1.0f, 1.0f, 1.0f, 1.0f);
 
         /// @brief
@@ -31,7 +29,6 @@ namespace tbx
         /// renderer normalizes the light color so intensity scales total light energy independent
         /// of hue (e.g., a red light at intensity 1.0 should be comparable to a white light at
         /// intensity 1.0).
-
         float intensity = 1.0f;
     };
 
@@ -40,7 +37,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type; callers own copies and manage component storage.
     /// Thread Safety: Safe to copy between threads; synchronize mutation externally.
-
     struct TBX_API PointLight : public Light
     {
         PointLight();
@@ -51,7 +47,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float range = 10.0f;
 
         /// @brief
@@ -59,7 +54,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         bool shadows_enabled = true;
     };
 
@@ -68,7 +62,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type; callers own copies and manage component storage.
     /// Thread Safety: Safe to copy between threads; synchronize mutation externally.
-
     struct TBX_API SpotLight : public Light
     {
         SpotLight();
@@ -84,7 +77,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float range = 10.0f;
 
         /// @brief
@@ -92,7 +84,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float inner_angle = 20.0f;
 
         /// @brief
@@ -100,7 +91,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float outer_angle = 35.0f;
     };
 
@@ -109,7 +99,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type; callers own copies and manage component storage.
     /// Thread Safety: Safe to copy between threads; synchronize mutation externally.
-
     struct TBX_API AreaLight : public Light
     {
         AreaLight();
@@ -124,7 +113,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float range = 10.0f;
 
         /// @brief
@@ -132,7 +120,6 @@ namespace tbx
         /// @details
         /// Ownership: Stored by value.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Vec2 area_size = Vec2(1.0f, 1.0f);
     };
 
@@ -141,7 +128,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type; callers own copies and manage component storage.
     /// Thread Safety: Safe to copy between threads; synchronize mutation externally.
-
     struct TBX_API DirectionalLight : public Light
     {
         DirectionalLight();
@@ -154,7 +140,6 @@ namespace tbx
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally. Notes: The
         /// renderer tints this ambient term using the directional light color and sums
         /// contributions across all directional lights.
-
         float ambient = 0.03f;
     };
 }

--- a/modules/graphics/include/tbx/graphics/material.h
+++ b/modules/graphics/include/tbx/graphics/material.h
@@ -31,7 +31,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     enum class MaterialDepthFunction : uint8_t
     {
         Less = 0,
@@ -44,7 +43,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     enum class MaterialBlendMode : uint8_t
     {
         Opaque = 0,
@@ -56,7 +54,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     enum class ShadowMode : uint8_t
     {
         None = 0,
@@ -69,7 +66,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the parameter name by value and stores the parameter payload inline.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialParameter
     {
         MaterialParameter() = default;
@@ -90,7 +86,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all parameter entries by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialParameterBindings
     {
         using iterator = std::vector<MaterialParameter>::iterator;
@@ -126,7 +121,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the binding name by value and texture instance by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialTextureBinding
     {
         std::string name = {};
@@ -138,7 +132,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all texture entries by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialTextureBindings
     {
         using iterator = std::vector<MaterialTextureBinding>::iterator;
@@ -175,7 +168,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct TBX_API MaterialDepthConfig
     {
         bool is_test_enabled = true;
@@ -189,7 +181,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct TBX_API MaterialTransparencyConfig
     {
         MaterialBlendMode blend_mode = MaterialBlendMode::Opaque;
@@ -200,7 +191,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type.
     /// Thread Safety: Safe to copy between threads.
-
     struct TBX_API MaterialRenderConfig
     {
         Depth depth = {};
@@ -212,7 +202,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type owned by the containing material asset.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialConfig
     {
         Depth depth = {};
@@ -228,7 +217,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns shader handles, default parameter bindings, default texture bindings, and
     /// config by value. Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API Material
     {
         ShaderProgram program = {};
@@ -242,11 +230,10 @@ namespace tbx
     /// @details
     /// Ownership: Owns the material handle and all override bindings by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API MaterialInstance
     {
         MaterialInstance();
-        explicit MaterialInstance(Handle handle);
+        MaterialInstance(Handle handle);
         MaterialInstance(
             Handle handle,
             ParamBindings parameter_overrides,
@@ -299,7 +286,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the material instance by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API Sky
     {
         MaterialInstance material = {};

--- a/modules/graphics/include/tbx/graphics/mesh.h
+++ b/modules/graphics/include/tbx/graphics/mesh.h
@@ -82,7 +82,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores a non-owning model handle reference.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API StaticMesh
     {
         /// @brief
@@ -90,7 +89,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle handle = {};
     };
 
@@ -100,7 +98,6 @@ namespace tbx
     /// Ownership: Holds a shared pointer to mesh data owned by callers or producer systems.
     /// Thread Safety: Mesh content mutation must be synchronized externally; the shared pointer
     /// itself is safe to copy between threads.
-
     struct TBX_API DynamicMesh
     {
         DynamicMesh() = default;
@@ -118,7 +115,6 @@ namespace tbx
         /// @details
         /// Ownership: Shared ownership of the mesh data via std::shared_ptr.
         /// Thread Safety: Safe to copy; synchronize mutation of the pointed-to Mesh externally.
-
         std::shared_ptr<Mesh> data = {};
     };
 }

--- a/modules/graphics/include/tbx/graphics/model.h
+++ b/modules/graphics/include/tbx/graphics/model.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores owned child indices and non-owning references via indices.
     /// Thread Safety: Safe to copy between threads.
-
     struct TBX_API ModelPart
     {
         /// @brief
@@ -21,7 +20,6 @@ namespace tbx
         /// @details
         /// Ownership: Value-owned matrix data with no external lifetime dependency.
         /// Thread Safety: Safe to read and copy concurrently.
-
         Mat4 transform = Mat4(1.0f);
         uint32 mesh_index = 0U;
         uint32 material_index = 0U;
@@ -33,7 +31,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns mesh, material, and part data by value.
     /// Thread Safety: Safe to construct on any thread.
-
     struct TBX_API Model
     {
         Model();

--- a/modules/graphics/include/tbx/graphics/post_processing.h
+++ b/modules/graphics/include/tbx/graphics/post_processing.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores a non-owning material handle reference and value settings.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API PostProcessingEffect
     {
         ~PostProcessingEffect();
@@ -22,7 +21,6 @@ namespace tbx
         /// @details
         /// Ownership: Owns parameter/texture override sets and a base material handle.
         /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
         MaterialInstance material = {};
 
         /// @brief
@@ -30,7 +28,6 @@ namespace tbx
         /// @details
         /// Ownership: Value type.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         bool is_enabled = true;
 
         /// @brief
@@ -38,7 +35,6 @@ namespace tbx
         /// @details
         /// Ownership: Value type.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         float blend = 1.0f;
     };
 
@@ -47,7 +43,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores value settings and an ordered effect stack by value.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API PostProcessing
     {
         ~PostProcessing();
@@ -57,7 +52,6 @@ namespace tbx
         /// @details
         /// Ownership: Owns the effect stack vector and effect settings.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         std::vector<PostProcessingEffect> effects = {};
 
         /// @brief
@@ -65,7 +59,6 @@ namespace tbx
         /// @details
         /// Ownership: Value type.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         bool is_enabled = true;
     };
 }

--- a/modules/graphics/include/tbx/graphics/renderer.h
+++ b/modules/graphics/include/tbx/graphics/renderer.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores handles by value; does not own loaded model assets.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API RendererLod
     {
         Handle handle = {};
@@ -23,7 +22,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the LOD collection by value.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API Lods
     {
         std::vector<RendererLod> values = {};

--- a/modules/graphics/include/tbx/graphics/shader.h
+++ b/modules/graphics/include/tbx/graphics/shader.h
@@ -18,7 +18,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not own resources.
     /// Thread Safety: Safe to read concurrently.
-
     enum class ShaderType
     {
         NONE,
@@ -34,7 +33,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns the source string data.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API ShaderSource
     {
         ShaderSource() = default;
@@ -53,15 +51,14 @@ namespace tbx
     /// @details
     /// Ownership: Owns the shader source collection.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API Shader
     {
         Shader() = default;
-        explicit Shader(ShaderSource shader_source)
+        Shader(ShaderSource shader_source)
             : sources({std::move(shader_source)})
         {
         }
-        explicit Shader(std::vector<ShaderSource> shader_sources)
+        Shader(std::vector<ShaderSource> shader_sources)
             : sources(std::move(shader_sources))
         {
         }
@@ -74,7 +71,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores stage handles by value; does not own loaded shader assets.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
-
     struct TBX_API ShaderProgram
     {
         /// @brief
@@ -82,7 +78,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle vertex = {};
 
         /// @brief
@@ -90,7 +85,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle fragment = {};
 
         /// @brief
@@ -98,7 +92,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle tesselation = {};
 
         /// @brief
@@ -106,7 +99,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle geometry = {};
 
         /// @brief
@@ -114,7 +106,6 @@ namespace tbx
         /// @details
         /// Ownership: Stores a non-owning handle reference.
         /// Thread Safety: Safe to read concurrently; synchronize mutation externally.
-
         Handle compute = {};
 
         /// @brief
@@ -122,7 +113,6 @@ namespace tbx
         /// @details
         /// Ownership: Stateless; no ownership transfer.
         /// Thread Safety: Safe to call concurrently.
-
         bool is_valid() const
         {
             const bool has_compute = compute.is_valid();

--- a/modules/graphics/include/tbx/graphics/texture.h
+++ b/modules/graphics/include/tbx/graphics/texture.h
@@ -50,7 +50,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type settings.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API TextureSettings
     {
         Size resolution = {1, 1};
@@ -102,7 +101,6 @@ namespace tbx
     /// @details
     /// Ownership: Stores a non-owning handle reference and optional value settings.
     /// Thread Safety: Safe to copy between threads; mutation requires external synchronization.
-
     struct TBX_API TextureInstance
     {
         Handle handle = {};

--- a/modules/graphics/include/tbx/graphics/vertex.h
+++ b/modules/graphics/include/tbx/graphics/vertex.h
@@ -11,7 +11,6 @@
 namespace tbx
 {
     /// ////////// VERTEX DATA //////////////////
-
     using VertexData = std::variant<int, float, Vec2, Vec3, Vec4, Color>;
 
     inline int32 get_vertex_data_count(const VertexData& data)
@@ -81,7 +80,6 @@ namespace tbx
     }
 
     /// ////////// VERTEX //////////////////
-
     struct TBX_API Vertex
     {
         // (x, y, z) in 3D space
@@ -97,7 +95,6 @@ namespace tbx
     };
 
     /// ////////// VERTEX BUFFER //////////////////
-
     inline std::vector<float> flatten_vertex_vector(const std::vector<Vertex>& vertices)
     {
         const auto vertex_count = vertices.size();

--- a/modules/graphics/include/tbx/graphics/window.h
+++ b/modules/graphics/include/tbx/graphics/window.h
@@ -13,7 +13,6 @@ namespace tbx
     /// @details
     /// Ownership: Non-owning opaque pointer; platform backend controls lifetime.
     /// Thread Safety: Pointer value is copyable; lifetime access must be externally synchronized.
-
     using NativeWindowHandle = void*;
 
     // Enumerates the presentation modes that a window can be configured for.

--- a/modules/input/include/tbx/input/input_action.h
+++ b/modules/input/include/tbx/input/input_action.h
@@ -491,7 +491,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns binding and callback collections by value.
     /// Thread Safety: Not thread-safe for mutation; synchronize externally if shared.
-
     struct TBX_API InputActionConstruction
     {
         std::vector<InputBinding> bindings = {};

--- a/modules/input/include/tbx/input/input_messages.h
+++ b/modules/input/include/tbx/input/input_messages.h
@@ -77,10 +77,9 @@ namespace tbx
     /// @details
     /// Ownership: The request owns the requested mode value.
     /// Thread Safety: Can be sent from any thread; backend handling is implementation-defined.
-
     struct TBX_API SetMouseLockRequest : public Request<void>
     {
-        explicit SetMouseLockRequest(MouseLockMode requested_lock_mode)
+        SetMouseLockRequest(MouseLockMode requested_lock_mode)
             : mode(requested_lock_mode)
         {
         }
@@ -102,7 +101,7 @@ namespace tbx
     /// Safety: Can be sent from any thread; backend handling is implementation-defined.
     struct TBX_API ControllerStateRequest : public Request<ControllerState>
     {
-        explicit ControllerStateRequest(int requested_index)
+        ControllerStateRequest(int requested_index)
             : controller_index(requested_index)
         {
         }

--- a/modules/math/include/tbx/math/matrices.h
+++ b/modules/math/include/tbx/math/matrices.h
@@ -71,7 +71,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a matrix by value; the caller owns the copy.
     /// Thread Safety: Stateless wrapper; safe to call concurrently.
-
     inline Mat3 inverse_transpose(const Mat3& matrix)
     {
         return glm::inverseTranspose(matrix);
@@ -114,7 +113,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a matrix by value; the caller owns the copy.
     /// Thread Safety: Stateless wrapper; safe to call concurrently.
-
     inline Mat4 build_transform_matrix(const Transform& transform)
     {
         Mat4 translation = translate(transform.position);

--- a/modules/math/include/tbx/math/quaternions.h
+++ b/modules/math/include/tbx/math/quaternions.h
@@ -8,7 +8,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using Quat = glm::quat;
 
     /// @brief
@@ -16,6 +15,5 @@ namespace tbx
     /// @details
     /// Ownership: returns a value copy; the caller owns the result.
     /// Thread Safety: stateless; safe to call concurrently.
-
     TBX_API Quat normalize(Quat q);
 }

--- a/modules/math/include/tbx/math/transform.h
+++ b/modules/math/include/tbx/math/transform.h
@@ -38,7 +38,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns an owned Transform value.
     /// Thread Safety: Stateless helper; safe to call concurrently.
-
     TBX_API Transform
         world_to_local_tranform(const Transform& parent_world, const Transform& world);
 }

--- a/modules/math/include/tbx/math/trig.h
+++ b/modules/math/include/tbx/math/trig.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float to_radians(float degrees);
 
     /// @brief
@@ -19,7 +18,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float to_degrees(float radians);
 
     /// @brief
@@ -27,7 +25,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API Vec3 to_radians(const Vec3& degrees);
 
     /// @brief
@@ -35,7 +32,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API Vec3 to_degrees(const Vec3& radians);
 
     /// @brief
@@ -43,7 +39,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float min(float left, float right);
 
     /// @brief
@@ -51,7 +46,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float max(float left, float right);
 
     /// @brief
@@ -59,7 +53,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float clamp(float value, float minimum_value, float maximum_value);
 
     /// @brief
@@ -67,7 +60,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float sqrt(float value);
 
     /// @brief
@@ -75,7 +67,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float floor(float value);
 
     /// @brief
@@ -83,7 +74,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float ceil(float value);
 
     TBX_API float cos(float x);

--- a/modules/math/include/tbx/math/vectors.h
+++ b/modules/math/include/tbx/math/vectors.h
@@ -8,7 +8,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using Vec2 = glm::vec2;
 
     /// @brief
@@ -16,7 +15,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using Vec3 = glm::vec3;
 
     /// @brief
@@ -24,7 +22,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using Vec4 = glm::vec4;
 
     /// @brief
@@ -32,7 +29,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using IVec2 = glm::ivec2;
 
     /// @brief
@@ -40,7 +36,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using IVec3 = glm::ivec3;
 
     /// @brief
@@ -48,7 +43,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using IVec4 = glm::ivec4;
 
     /// @brief
@@ -56,7 +50,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using UVec2 = glm::uvec2;
 
     /// @brief
@@ -65,7 +58,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using UVec3 = glm::uvec3;
 
     /// @brief
@@ -73,7 +65,6 @@ namespace tbx
     /// @details
     /// Ownership: value type; callers own any copies created from this alias.
     /// Thread Safety: immutable value semantics; safe for concurrent use when not shared mutably.
-
     using UVec4 = glm::uvec4;
 
     /// @brief
@@ -81,7 +72,6 @@ namespace tbx
     /// @details
     /// Ownership: returns a value copy; the caller owns the result.
     /// Thread Safety: stateless; safe to call concurrently.
-
     TBX_API Vec2 normalize(Vec2 v);
 
     /// @brief
@@ -89,7 +79,6 @@ namespace tbx
     /// @details
     /// Ownership: returns a value copy; the caller owns the result.
     /// Thread Safety: stateless; safe to call concurrently.
-
     TBX_API Vec3 normalize(Vec3 v);
 
     /// @brief
@@ -97,7 +86,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value copy; the caller owns the result.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float dot(const Vec3& left, const Vec3& right);
 
     /// @brief
@@ -105,7 +93,6 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value copy; the caller owns the result.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API Vec3 cross(const Vec3& left, const Vec3& right);
 
     /// @brief
@@ -113,7 +100,6 @@ namespace tbx
     /// @details
     /// Ownership: returns a value copy; the caller owns the result.
     /// Thread Safety: stateless; safe to call concurrently.
-
     TBX_API Vec4 normalize(Vec4 v);
 
     /// @brief
@@ -121,6 +107,5 @@ namespace tbx
     /// @details
     /// Ownership: Returns a value type.
     /// Thread Safety: Stateless; safe to call concurrently.
-
     TBX_API float distance(const Vec3& a, const Vec3& b);
 }

--- a/modules/messaging/include/tbx/messages/dispatcher.h
+++ b/modules/messaging/include/tbx/messages/dispatcher.h
@@ -17,7 +17,6 @@ namespace tbx
     /// ownership of a queued copy while `send` uses a stack instance. Thread Safety:
     /// Implementations may define their own guarantees. Unless documented otherwise by the concrete
     /// type, calls are expected from the engine's main thread.
-
     class TBX_API IMessageDispatcher
     {
       public:
@@ -28,7 +27,6 @@ namespace tbx
         /// @details
         /// Ownership: The caller retains ownership; the dispatcher operates on the provided object.
         /// Thread Safety: See class notes.
-
         template <typename TMessage>
             requires std::derived_from<TMessage, Message>
         Result send(TMessage& msg) const
@@ -41,7 +39,6 @@ namespace tbx
         /// @details
         /// Ownership: The message is constructed in-place for the dispatch.
         /// Thread Safety: See class notes.
-
         template <typename TMessage, typename... TArgs>
             requires(
                 std::derived_from<TMessage, Message> && (sizeof...(TArgs) > 0)
@@ -57,7 +54,6 @@ namespace tbx
         /// @details
         /// Ownership: Copies the message for queued delivery.
         /// Thread Safety: See class notes.
-
         template <typename TMessage>
             requires std::derived_from<TMessage, Message>
         std::shared_future<Result> post(const TMessage& msg) const
@@ -70,7 +66,6 @@ namespace tbx
         /// @details
         /// Ownership: Takes ownership of the queued copy until delivery. Returns a future that
         /// becomes ready once processing completes. Thread Safety: See class notes.
-
         template <typename TMessage, typename... TArgs>
             requires(
                 std::derived_from<TMessage, Message> && (sizeof...(TArgs) > 0)
@@ -92,7 +87,6 @@ namespace tbx
     /// Ownership: Implementations own their queued messages and handler registrations.
     /// Thread Safety: Not required to be thread-safe; expected single-thread usage unless
     /// documented otherwise by an implementation.
-
     class TBX_API IMessageQueue
     {
       public:
@@ -103,7 +97,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not transfer ownership of queued message storage.
         /// Thread Safety: See class notes.
-
         virtual void flush() = 0;
     };
 
@@ -112,7 +105,6 @@ namespace tbx
     /// @details
     /// Ownership: Implementations own stored handlers and their lifetimes.
     /// Thread Safety: Implementations define their own guarantees.
-
     class TBX_API IMessageHandlerRegistrar
     {
       public:
@@ -123,7 +115,6 @@ namespace tbx
         /// @details
         /// Ownership: The registrar stores the handler by value.
         /// Thread Safety: See class notes.
-
         virtual Uuid register_handler(MessageHandler handler) = 0;
 
         /// @brief
@@ -131,7 +122,6 @@ namespace tbx
         /// @details
         /// Ownership: The registrar releases its stored handler for the token.
         /// Thread Safety: See class notes.
-
         virtual void deregister_handler(const Uuid& token) = 0;
 
         /// @brief
@@ -139,7 +129,6 @@ namespace tbx
         /// @details
         /// Ownership: The registrar releases all stored handlers.
         /// Thread Safety: See class notes.
-
         virtual void clear_handlers() = 0;
     };
 
@@ -150,7 +139,6 @@ namespace tbx
     /// Ownership: Implementations own their handlers and queued messages; callers receive
     /// non-owning references. Thread Safety: Not required to be thread-safe; expected single-thread
     /// usage unless documented otherwise by an implementation.
-
     class TBX_API IMessageCoordinator
         : public IMessageDispatcher
         , public IMessageQueue
@@ -166,7 +154,6 @@ namespace tbx
     /// Ownership: Non-owning. The setter retains ownership and must ensure the dispatcher outlives
     /// its use through this API. Thread Safety: Thread-safe. Uses an atomic pointer to read the
     /// global dispatcher without additional synchronization.
-
     TBX_API IMessageDispatcher* get_global_dispatcher();
 
     /// @brief
@@ -175,7 +162,6 @@ namespace tbx
     /// Ownership: Non-owning. The caller retains ownership and must ensure the dispatcher outlives
     /// all use through this API. Thread Safety: Thread-safe. Uses an atomic pointer to exchange the
     /// dispatcher value for the process.
-
     TBX_API IMessageDispatcher* set_global_dispatcher(IMessageDispatcher* dispatcher);
 
     /// @brief
@@ -186,7 +172,6 @@ namespace tbx
     /// the scope where it is set. Thread Safety: Thread-safe for setting and restoring the global
     /// dispatcher pointer. The dispatcher instance itself must remain valid for the lifetime of the
     /// scope.
-
     class TBX_API GlobalDispatcherScope
     {
       public:

--- a/modules/messaging/include/tbx/messages/message.h
+++ b/modules/messaging/include/tbx/messages/message.h
@@ -91,7 +91,6 @@ namespace tbx
     /// Ownership: Non-owning. The coordinator stores a copy of the callable.
     /// Thread Safety: Invoked on the coordinator's calling thread; handlers should avoid blocking
     /// and must manage their own synchronization if touching shared state.
-
     using MessageHandler = std::function<void(Message&)>;
 
     /// @brief
@@ -99,7 +98,6 @@ namespace tbx
     /// @details
     /// Ownership: Non-owning; the returned pointer borrows from the input message.
     /// Thread Safety: Matches the caller's context. No synchronization is applied.
-
     template <typename TMessage>
     const TMessage* handle_message(const Message& message)
     {
@@ -111,7 +109,6 @@ namespace tbx
     /// @details
     /// Ownership: Non-owning; the returned pointer borrows from the input message.
     /// Thread Safety: Matches the caller's context. No synchronization is applied.
-
     template <typename TMessage>
     TMessage* handle_message(Message& message)
     {

--- a/modules/messaging/include/tbx/messages/observable.h
+++ b/modules/messaging/include/tbx/messages/observable.h
@@ -119,7 +119,6 @@ namespace tbx
     /// @details
     /// Ownership: Type-only helper; no runtime ownership or storage.
     /// Thread Safety: Not applicable; compile-time only.
-
     template <auto TMember>
     struct ObservableMemberTraits;
 
@@ -128,7 +127,6 @@ namespace tbx
     /// @details
     /// Ownership: Type-only helper; no runtime ownership or storage.
     /// Thread Safety: Not applicable; compile-time only.
-
     template <typename TOwner, typename TProp, Observable<TOwner, TProp> TOwner::* TMember>
     struct ObservableMemberTraits<TMember>
     {
@@ -142,7 +140,6 @@ namespace tbx
     /// @details
     /// Ownership: Non-owning; the output pointer borrows from the input message.
     /// Thread Safety: Matches the caller's context. No synchronization is applied.
-
     template <auto TMember>
     PropertyChangedEvent<typename ObservableMemberTraits<TMember>::Owner, typename ObservableMemberTraits<TMember>::Property>* handle_property_changed(
         Message& msg)
@@ -164,7 +161,6 @@ namespace tbx
     /// @details
     /// Ownership: Non-owning; the output pointer borrows from the input message.
     /// Thread Safety: Matches the caller's context. No synchronization is applied.
-
     template <auto TMember>
     const PropertyChangedEvent<typename ObservableMemberTraits<TMember>::Owner, typename ObservableMemberTraits<TMember>::Property>* handle_property_changed(
         const Message& msg)

--- a/modules/physics/include/tbx/physics/collider.h
+++ b/modules/physics/include/tbx/physics/collider.h
@@ -12,7 +12,6 @@ namespace tbx
     /// @details
     /// Ownership: Value enum copied by value.
     /// Thread Safety: Immutable enum values; safe for concurrent reads.
-
     enum class ColliderOverlapExecutionMode
     {
         AUTO = 0,
@@ -24,7 +23,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type containing non-owning entity identifiers.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API ColliderOverlapEvent
     {
         Uuid trigger_entity_id = {};
@@ -36,7 +34,6 @@ namespace tbx
     /// @details
     /// Ownership: Callback lifetime is owned by the registering trigger callback list.
     /// Thread Safety: Invoked by runtime physics update on the main thread.
-
     using ColliderOverlapCallback = std::function<void(const ColliderOverlapEvent&)>;
 
     /// @brief
@@ -44,7 +41,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns overlap query state and callback lists by value.
     /// Thread Safety: Not thread-safe; mutate and trigger from the main thread.
-
     struct TBX_API ColliderTrigger
     {
         bool is_trigger_only = false;
@@ -61,7 +57,6 @@ namespace tbx
         /// @details
         /// Ownership: Mutates this trigger collider state in place.
         /// Thread Safety: Not thread-safe; call from the main thread.
-
         void request_overlap_scan();
     };
 
@@ -71,7 +66,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns mesh collider settings by value only; geometry ownership stays with the mesh
     /// component. Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API MeshCollider
     {
         bool is_convex = true;
@@ -83,7 +77,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns size data by value.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API CubeCollider
     {
         Vec3 half_extents = Vec3(0.5F, 0.5F, 0.5F);
@@ -95,7 +88,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns radius data by value.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API SphereCollider
     {
         float radius = 0.5F;
@@ -107,7 +99,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns capsule dimensions by value.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API CapsuleCollider
     {
         float radius = 0.5F;

--- a/modules/physics/include/tbx/physics/physics.h
+++ b/modules/physics/include/tbx/physics/physics.h
@@ -10,7 +10,6 @@ namespace tbx
     /// @details
     /// Ownership: Value enum copied by value.
     /// Thread Safety: Immutable enum values; safe for concurrent reads.
-
     enum class PhysicsTransformSyncMode
     {
         NONE = 0,
@@ -23,7 +22,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type that owns all component data by copy.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API Physics
     {
         float mass = 1.0F;

--- a/modules/physics/include/tbx/physics/physics_settings.h
+++ b/modules/physics/include/tbx/physics/physics_settings.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Owns all configuration values by value.
     /// Thread Safety: Not thread-safe; synchronize access externally.
-
     struct TBX_API PhysicsSettings
     {
         PhysicsSettings(IMessageDispatcher& dispatcher);

--- a/modules/physics/include/tbx/physics/raycast.h
+++ b/modules/physics/include/tbx/physics/raycast.h
@@ -11,7 +11,6 @@ namespace tbx
     /// @details
     /// Ownership: Value type containing non-owning entity identifiers.
     /// Thread Safety: Safe for concurrent reads; synchronize external mutation.
-
     struct TBX_API RaycastResult
     {
         bool has_hit = false;
@@ -32,7 +31,6 @@ namespace tbx
     /// Ownership: Value type that owns query parameters by copy.
     /// Thread Safety: Safe for concurrent reads; calling methods requires a valid thread-safe
     /// global dispatcher.
-
     struct TBX_API Raycast
     {
         Vec3 origin = Vec3(0.0F, 0.0F, 0.0F);
@@ -46,7 +44,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes the result into the caller-provided output value.
         /// Thread Safety: Thread-safe if the global dispatcher implementation is thread-safe.
-
         bool try_cast(RaycastResult& out_result) const;
 
         /// @brief
@@ -55,7 +52,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns the result by value.
         /// Thread Safety: Thread-safe if the global dispatcher implementation is thread-safe.
-
         RaycastResult cast() const;
     };
 
@@ -64,10 +60,9 @@ namespace tbx
     /// @details
     /// Ownership: Owns a copy of the raycast query payload.
     /// Thread Safety: Safe to construct on any thread; handling depends on the dispatcher backend.
-
     struct TBX_API RaycastRequest : public Request<RaycastResult>
     {
-        explicit RaycastRequest(const Raycast& raycast_query);
+        RaycastRequest(const Raycast& raycast_query);
         ~RaycastRequest() noexcept override;
 
         Raycast raycast = {};

--- a/modules/plugin_api/include/tbx/plugin_api/plugin.h
+++ b/modules/plugin_api/include/tbx/plugin_api/plugin.h
@@ -30,7 +30,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not own the host or dispatcher references.
         /// Thread Safety: Not thread-safe; must be called exactly once before use.
-
         void attach(IPluginHost& host);
 
         /// @brief
@@ -38,7 +37,6 @@ namespace tbx
         /// @details
         /// Ownership: Does not own the host or dispatcher references.
         /// Thread Safety: Not thread-safe; call from the main thread.
-
         void detach();
 
         // Ticks the plugin for the given frame delta.

--- a/modules/plugin_api/include/tbx/plugin_api/plugin_export.h
+++ b/modules/plugin_api/include/tbx/plugin_api/plugin_export.h
@@ -9,7 +9,6 @@
         /// @details
         /// Ownership: Preprocessor macro with no ownership semantics.
         /// Thread Safety: Compile-time only.
-
             #define TBX_PLUGIN_API __declspec(dllexport)
         #else
         /// @brief
@@ -18,7 +17,6 @@
         /// @details
         /// Ownership: Preprocessor macro with no ownership semantics.
         /// Thread Safety: Compile-time only.
-
             #define TBX_PLUGIN_API __declspec(dllimport)
         #endif
     #else

--- a/modules/plugin_api/include/tbx/plugin_api/plugin_host.h
+++ b/modules/plugin_api/include/tbx/plugin_api/plugin_host.h
@@ -17,7 +17,6 @@ namespace tbx
     /// @details
     /// Ownership: Implementations retain ownership of returned references.
     /// Thread Safety: Not thread-safe; expected to be used on the main thread.
-
     class TBX_API IPluginHost
     {
       public:
@@ -28,7 +27,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual const std::string& get_name() const = 0;
 
         /// @brief
@@ -36,7 +34,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual const Handle& get_icon_handle() const = 0;
 
         /// @brief
@@ -44,7 +41,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual AppSettings& get_settings() = 0;
 
         /// @brief
@@ -52,7 +48,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual IMessageCoordinator& get_message_coordinator() = 0;
 
         /// @brief
@@ -60,7 +55,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual InputManager& get_input_manager() = 0;
 
         /// @brief
@@ -68,7 +62,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual EntityRegistry& get_entity_registry() = 0;
 
         /// @brief
@@ -76,7 +69,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Not thread-safe; synchronize access externally.
-
         virtual AssetManager& get_asset_manager() = 0;
 
         /// @brief
@@ -84,7 +76,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Thread-safe according to JobSystem guarantees.
-
         virtual JobSystem& get_job_system() = 0;
 
         /// @brief
@@ -92,7 +83,6 @@ namespace tbx
         /// @details
         /// Ownership: Returns a reference owned by the host.
         /// Thread Safety: Thread-safe according to ThreadManager guarantees.
-
         virtual ThreadManager& get_thread_manager() = 0;
     };
 }

--- a/modules/plugin_api/include/tbx/plugin_api/plugin_loader.h
+++ b/modules/plugin_api/include/tbx/plugin_api/plugin_loader.h
@@ -41,7 +41,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not take ownership of plugin instances.
     /// Thread Safety: Not thread-safe; call from the main thread.
-
     TBX_API void update_plugins(std::vector<LoadedPlugin>& loaded_plugins, const DeltaTime& dt);
 
     /// @brief
@@ -50,7 +49,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not take ownership of plugin instances.
     /// Thread Safety: Not thread-safe; call from the main thread.
-
     TBX_API void update_plugins_fixed(
         std::vector<LoadedPlugin>& loaded_plugins,
         const DeltaTime& dt);

--- a/modules/plugin_api/include/tbx/plugin_api/plugin_meta.h
+++ b/modules/plugin_api/include/tbx/plugin_api/plugin_meta.h
@@ -18,7 +18,6 @@ namespace tbx
     /// @details
     /// Ownership: Not applicable.
     /// Thread Safety: Immutable constant.
-
     inline constexpr uint32 PluginAbiVersion = static_cast<uint32>(TBX_PLUGIN_ABI_VERSION);
 
     /// @brief
@@ -26,7 +25,6 @@ namespace tbx
     /// @details
     /// Ownership: Not applicable.
     /// Thread Safety: Immutable enum values.
-
     enum class PluginCategory : uint32
     {
         DEFAULT = 0,
@@ -82,7 +80,6 @@ namespace tbx
     /// @details
     /// Ownership: Does not own file handles; reads data through FileOperator.
     /// Thread Safety: Safe to use concurrently when the file operator is thread-safe.
-
     class TBX_API PluginMetaParser final
     {
       public:
@@ -91,7 +88,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes metadata into the caller-provided struct on success.
         /// Thread Safety: Safe to call concurrently when the file operator is thread-safe.
-
         bool try_parse_from_disk(
             const std::filesystem::path& working_directory,
             const std::filesystem::path& manifest_path,
@@ -102,7 +98,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes metadata into the caller-provided struct on success.
         /// Thread Safety: Safe to call concurrently.
-
         bool try_parse_from_source(
             std::string_view manifest_text,
             const std::filesystem::path& manifest_path,

--- a/modules/plugin_api/include/tbx/plugin_api/shared_library.h
+++ b/modules/plugin_api/include/tbx/plugin_api/shared_library.h
@@ -49,7 +49,6 @@ namespace tbx
         /// @details
         /// Ownership: Writes a copy of the stored message into the caller-provided string.
         /// Thread Safety: Not thread-safe; synchronize external access if shared.
-
         bool try_get_load_error_message(std::string& out_error_message) const;
 
       private:

--- a/modules/plugin_api/src/plugin_meta.cpp
+++ b/modules/plugin_api/src/plugin_meta.cpp
@@ -132,7 +132,6 @@ namespace tbx
 
     /// @brief
     /// Converts manifest JSON data into a populated PluginMeta structure.
-
     static bool try_parse_plugin_meta_data(
         const Json& data,
         const std::filesystem::path& manifest_path,
@@ -224,7 +223,6 @@ namespace tbx
 
     /// @brief
     /// Parses plugin metadata from raw JSON text.
-
     bool PluginMetaParser::try_parse_from_source(
         std::string_view manifest_text,
         const std::filesystem::path& manifest_path,
@@ -245,7 +243,6 @@ namespace tbx
 
     /// @brief
     /// Opens the manifest on disk and parses plugin metadata.
-
     bool PluginMetaParser::try_parse_from_disk(
         const std::filesystem::path& working_directory,
         const std::filesystem::path& manifest_path,

--- a/modules/plugin_api/tests/include/tbx/plugin_api/tests/importer_test_environment.h
+++ b/modules/plugin_api/tests/include/tbx/plugin_api/tests/importer_test_environment.h
@@ -17,11 +17,10 @@ namespace tbx::tests::plugin_api
     /// receive copied data.
     /// Thread Safety: Not thread-safe; use on a single thread or protect with external
     /// synchronization.
-
     class InMemoryFileOps final : public IFileOps
     {
       public:
-        explicit InMemoryFileOps(std::filesystem::path working_directory)
+        InMemoryFileOps(std::filesystem::path working_directory)
             : _working_directory(std::move(working_directory))
         {
         }
@@ -95,7 +94,6 @@ namespace tbx::tests::plugin_api
     /// Purpose: Returns a deterministic absolute-style working directory path for tests on each
     /// platform. Ownership: Returns a value path object with no shared lifetime requirements.
     /// Thread Safety: Thread-safe; no shared mutable state.
-
     static std::filesystem::path get_test_working_directory()
     {
 #if defined(_WIN32)
@@ -110,11 +108,10 @@ namespace tbx::tests::plugin_api
     /// tests. Ownership: Owns coordinator, registry, settings, and asset manager for the test
     /// lifetime. Thread Safety: Not thread-safe; intended for single-threaded test setup and
     /// execution.
-
     class TestPluginHost final : public IPluginHost
     {
       public:
-        explicit TestPluginHost(const std::filesystem::path& working_directory)
+        TestPluginHost(const std::filesystem::path& working_directory)
             : _asset_manager(working_directory, {}, {}, false)
             , _settings(_coordinator, true, GraphicsApi::OPEN_GL, {640, 480})
         {

--- a/modules/plugin_api/tests/plugin_loader_tests.cpp
+++ b/modules/plugin_api/tests/plugin_loader_tests.cpp
@@ -21,7 +21,7 @@ namespace tbx::tests::plugin_loader
     class TestPluginHost final : public ::tbx::IPluginHost
     {
       public:
-        explicit TestPluginHost(const std::filesystem::path& working_directory)
+        TestPluginHost(const std::filesystem::path& working_directory)
             : _asset_manager(working_directory)
             , _settings(_coordinator, true, ::tbx::GraphicsApi::OPEN_GL, {1280, 720})
         {

--- a/plugins/jolt_physics/include/tbx/plugins/jolt_physics/jolt_physics_plugin.h
+++ b/plugins/jolt_physics/include/tbx/plugins/jolt_physics/jolt_physics_plugin.h
@@ -24,7 +24,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Plain value type owned by `JoltPhysicsPlugin` body maps; no resource ownership.
     /// Thread Safety: Not thread-safe; accessed on the plugin physics lane.
-
     struct JoltBodyRecord
     {
         JPH::BodyID body_id = {};

--- a/plugins/jolt_physics/src/jolt_collision_layers.h
+++ b/plugins/jolt_physics/src/jolt_collision_layers.h
@@ -10,7 +10,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Returns a value; no ownership transfer.
     /// Thread Safety: Thread-safe and immutable.
-
     JPH::ObjectLayer get_static_object_layer();
 
     /// @brief
@@ -18,7 +17,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Returns a value; no ownership transfer.
     /// Thread Safety: Thread-safe and immutable.
-
     JPH::ObjectLayer get_moving_object_layer();
 
     /// @brief
@@ -26,7 +24,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Returns a non-owning reference to a process-lifetime singleton.
     /// Thread Safety: Thread-safe for concurrent read-only access.
-
     const JPH::BroadPhaseLayerInterface& get_broad_phase_layer_interface();
 
     /// @brief
@@ -34,7 +31,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Returns a non-owning reference to a process-lifetime singleton.
     /// Thread Safety: Thread-safe for concurrent read-only access.
-
     const JPH::ObjectVsBroadPhaseLayerFilter& get_object_vs_broad_phase_layer_filter();
 
     /// @brief
@@ -42,6 +38,5 @@ namespace jolt_physics
     /// @details
     /// Ownership: Returns a non-owning reference to a process-lifetime singleton.
     /// Thread Safety: Thread-safe for concurrent read-only access.
-
     const JPH::ObjectLayerPairFilter& get_object_layer_pair_filter();
 }

--- a/plugins/jolt_physics/src/jolt_runtime_lifetime.h
+++ b/plugins/jolt_physics/src/jolt_runtime_lifetime.h
@@ -7,7 +7,6 @@ namespace jolt_physics
     /// @details
     /// Ownership: Owns process-wide runtime reference counting only; does not own plugin state.
     /// Thread Safety: Thread-safe; acquire/release are synchronized internally.
-
     class JoltRuntimeLifetime final
     {
       public:

--- a/plugins/mat_material_loader/include/tbx/plugins/mat_material_loader/mat_material_loader_plugin.h
+++ b/plugins/mat_material_loader/include/tbx/plugins/mat_material_loader/mat_material_loader_plugin.h
@@ -11,42 +11,22 @@ namespace mat_material_loader
 {
     /// @brief
     /// Purpose: Loads material assets from .mat JSON files.
-
     /// @details
     /// Ownership: tbx::Plugin lifetime is owned by the host; it keeps non-owning references to the
     /// host. Thread Safety: Handles asset messages on the dispatcher thread; no internal
     /// synchronization.
-
     class TBX_PLUGIN_API MatMaterialLoaderPlugin final : public tbx::Plugin
     {
       public:
-        /// @brief
-        /// Purpose: Captures host references needed for asset resolution.
-
-        /// @details
-        /// Ownership: Does not take ownership of the host.
-        /// Thread Safety: Called on the main thread during plugin attach.
-
         void on_attach(tbx::IPluginHost& host) override;
-
-        /// @brief
-        /// Purpose: Releases any cached host references.
-
-        /// @details
-        /// Ownership: Does not destroy host resources.
-        /// Thread Safety: Called on the main thread during plugin detach.
-
         void on_detach() override;
 
         /// @brief
         /// Purpose: Receives material load requests and dispatches file parsing.
-
-        /// @brief
-        /// Purpose: synchronization.
         /// @details
         /// Ownership: Does not take ownership of messages or asset payloads.
         /// Thread Safety: Executes on the dispatcher thread; relies on tbx::Material payload
-
+        /// synchronization.
         void on_recieve_message(tbx::Message& msg) override;
 
       private:

--- a/plugins/opengl_rendering/include/tbx/plugins/opengl_rendering/opengl_rendering_plugin.h
+++ b/plugins/opengl_rendering/include/tbx/plugins/opengl_rendering/opengl_rendering_plugin.h
@@ -14,7 +14,6 @@ namespace opengl_rendering
     /// Ownership: Plugin owns renderer instances and borrows host systems during attach/detach.
     /// Thread Safety: Public callbacks are expected to run on the host thread; render work is
     /// posted to a dedicated render lane.
-
     class TBX_PLUGIN_API OpenGlRenderingPlugin final : public tbx::Plugin
     {
       public:

--- a/plugins/opengl_rendering/src/gl_id_provider.h
+++ b/plugins/opengl_rendering/src/gl_id_provider.h
@@ -10,7 +10,6 @@ namespace opengl_rendering
     /// @details
     /// Ownership: Stateless; does not own external resources.
     /// Thread Safety: Safe to call concurrently.
-
     class GlIdProvider final
     {
       public:
@@ -19,7 +18,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a value type; the caller owns the copy.
         /// Thread Safety: Safe to call concurrently.
-
         tbx::Uuid provide(const tbx::Uuid& first, tbx::uint32 second) const;
     };
 }

--- a/plugins/opengl_rendering/src/opengl_resources/opengl_buffers.h
+++ b/plugins/opengl_rendering/src/opengl_resources/opengl_buffers.h
@@ -65,11 +65,9 @@ namespace opengl_rendering
     /// @brief
     /// Purpose: Owns deferred-rendering attachments used by future multi-pass rendering and debug
     /// presentation.
-
     /// @details
     /// Ownership: Owns OpenGL framebuffer and texture handles for the lifetime of this object.
     /// Thread Safety: Not thread-safe; use only on the active render thread/context.
-
     class OpenGlGBuffer final : public IOpenGlResource
     {
       public:
@@ -83,7 +81,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Keeps ownership of all allocated OpenGL objects.
         /// Thread Safety: Not thread-safe; caller must synchronize access.
-
         void resize(const tbx::Size& size);
 
         /// @brief
@@ -91,7 +88,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not transfer framebuffer ownership.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void prepare_geometry_pass() const;
 
         /// @brief
@@ -99,7 +95,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not transfer ownership of any OpenGL object.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void present(tbx::RenderStage render_stage, const tbx::Size& viewport_size) const;
 
         /// @brief
@@ -107,7 +102,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not transfer ownership of any OpenGL object.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void bind() override;
 
         /// @brief
@@ -115,7 +109,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not transfer ownership of any OpenGL object.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void unbind() override;
 
         /// @brief
@@ -123,7 +116,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         GLuint get_albedo_texture() const;
 
         /// @brief
@@ -131,7 +123,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         GLuint get_normal_texture() const;
 
         /// @brief
@@ -139,7 +130,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         GLuint get_emissive_texture() const;
 
         /// @brief
@@ -147,7 +137,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         GLuint get_material_texture() const;
 
         /// @brief
@@ -155,7 +144,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         GLuint get_depth_texture() const;
 
       private:

--- a/plugins/opengl_rendering/src/opengl_resources/opengl_mesh.h
+++ b/plugins/opengl_rendering/src/opengl_resources/opengl_mesh.h
@@ -23,7 +23,7 @@ namespace opengl_rendering
     class OpenGlMesh final : public IOpenGlResource
     {
       public:
-        explicit OpenGlMesh(const tbx::Mesh& mesh);
+        OpenGlMesh(const tbx::Mesh& mesh);
         OpenGlMesh(const OpenGlMesh&) = delete;
         OpenGlMesh& operator=(const OpenGlMesh&) = delete;
         OpenGlMesh(OpenGlMesh&& other) noexcept;

--- a/plugins/opengl_rendering/src/opengl_resources/opengl_model.h
+++ b/plugins/opengl_rendering/src/opengl_resources/opengl_model.h
@@ -8,11 +8,9 @@ namespace opengl_rendering
 {
     /// @brief
     /// Purpose: Stores OpenGL-resolved data for a model part.
-
     /// @details
     /// Ownership: Owns transform and child index data; references GPU resources by UUID.
     /// Thread Safety: Not thread-safe; use on the render thread.
-
     struct OpenGlModelPart
     {
         tbx::Mat4 transform = tbx::Mat4(1.0f);
@@ -23,11 +21,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Represents a GPU-ready model cache for OpenGL rendering.
-
     /// @details
     /// Ownership: Owns part hierarchy data and mesh references by UUID.
     /// Thread Safety: Not thread-safe; use on the render thread.
-
     struct OpenGlModel
     {
         tbx::Uuid model_id = {};

--- a/plugins/opengl_rendering/src/opengl_resources/opengl_shader.h
+++ b/plugins/opengl_rendering/src/opengl_resources/opengl_shader.h
@@ -38,7 +38,7 @@ namespace opengl_rendering
     class OpenGlShader final : public IOpenGlResource
     {
       public:
-        explicit OpenGlShader(const tbx::ShaderSource& shader);
+        OpenGlShader(const tbx::ShaderSource& shader);
         OpenGlShader(const OpenGlShader&) = delete;
         OpenGlShader& operator=(const OpenGlShader&) = delete;
         OpenGlShader(OpenGlShader&& other) noexcept;
@@ -63,7 +63,7 @@ namespace opengl_rendering
     class OpenGlShaderProgram final : public IOpenGlResource
     {
       public:
-        explicit OpenGlShaderProgram(const std::vector<std::shared_ptr<OpenGlShader>>& shaders);
+        OpenGlShaderProgram(const std::vector<std::shared_ptr<OpenGlShader>>& shaders);
         OpenGlShaderProgram(const OpenGlShaderProgram&) = delete;
         OpenGlShaderProgram& operator=(const OpenGlShaderProgram&) = delete;
         OpenGlShaderProgram(OpenGlShaderProgram&& other) noexcept;

--- a/plugins/opengl_rendering/src/pipeline/LightingPassOperation.h
+++ b/plugins/opengl_rendering/src/pipeline/LightingPassOperation.h
@@ -14,11 +14,9 @@ namespace opengl_rendering
     /// @brief
     /// Purpose: Resolves deferred lighting from the geometry attachments into the final color
     /// target.
-
     /// @details
     /// Ownership: Owns the fullscreen draw state and shader program it creates lazily.
     /// Thread Safety: Not thread-safe; render-thread only.
-
     class LightingPassOperation final
     {
       public:
@@ -36,7 +34,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not take ownership of the supplied payload.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void execute(const std::any& payload);
 
       private:

--- a/plugins/opengl_rendering/src/pipeline/OpenGlFrameContext.h
+++ b/plugins/opengl_rendering/src/pipeline/OpenGlFrameContext.h
@@ -25,11 +25,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one mesh batch for directional shadow-map rendering.
-
     /// @details
     /// Ownership: Stores mesh handles and transforms by value for one frame.
     /// Thread Safety: Safe to move between threads; render-thread mutation only.
-
     struct ShadowDrawCall
     {
         bool is_two_sided = false;
@@ -41,11 +39,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one transparent surface draw submitted after deferred lighting.
-
     /// @details
     /// Ownership: Stores mesh, transform, and material data by value for one frame.
     /// Thread Safety: Safe to move between threads; render-thread mutation only.
-
     struct TransparentDrawCall
     {
         tbx::Uuid shader_program = {};
@@ -58,11 +54,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one directional light in the render-thread frame payload.
-
     /// @details
     /// Ownership: Value type copied into the frame context.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct DirectionalLightFrameData
     {
         tbx::Vec3 direction = tbx::Vec3(0.0F, 0.0F, -1.0F);
@@ -77,11 +71,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Stores one stabilized directional shadow cascade for the lighting pass.
-
     /// @details
     /// Ownership: Value type copied into the frame context and GPU upload payloads.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct ShadowCascadeFrameData
     {
         tbx::Mat4 light_view_projection = tbx::Mat4(1.0F);
@@ -96,11 +88,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Stores one projected local-light shadow map for spot and area lights.
-
     /// @details
     /// Ownership: Value type copied into the frame context and GPU upload payloads.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct ProjectedShadowFrameData
     {
         tbx::Mat4 light_view_projection = tbx::Mat4(1.0F);
@@ -116,11 +106,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Stores directional shadow-map state consumed by render passes for one frame.
-
     /// @details
     /// Ownership: Owns cascade values by copy and references no external resources.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct ShadowFrameData
     {
         tbx::uint32 directional_map_resolution = 2048U;
@@ -135,11 +123,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one point light in the render-thread frame payload.
-
     /// @details
     /// Ownership: Value type copied into the frame context.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct PointLightFrameData
     {
         tbx::Vec3 position = tbx::Vec3(0.0F, 0.0F, 0.0F);
@@ -153,11 +139,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one spot light in the render-thread frame payload.
-
     /// @details
     /// Ownership: Value type copied into the frame context.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct SpotLightFrameData
     {
         tbx::Vec3 position = tbx::Vec3(0.0F, 0.0F, 0.0F);
@@ -173,11 +157,9 @@ namespace opengl_rendering
 
     /// @brief
     /// Purpose: Captures one rectangular area light in the render-thread frame payload.
-
     /// @details
     /// Ownership: Value type copied into the frame context.
     /// Thread Safety: Safe to copy between threads; render-thread mutation only.
-
     struct AreaLightFrameData
     {
         tbx::Vec3 position = tbx::Vec3(0.0F, 0.0F, 0.0F);

--- a/plugins/opengl_rendering/src/pipeline/ShadowPassOperation.h
+++ b/plugins/opengl_rendering/src/pipeline/ShadowPassOperation.h
@@ -10,11 +10,9 @@ namespace opengl_rendering
     /// @brief
     /// Purpose: Renders realtime shadow maps for deferred directional, point, spot, and area
     /// lights.
-
     /// @details
     /// Ownership: Owns the shadow framebuffer, depth textures, and shadow shader program.
     /// Thread Safety: Not thread-safe; render-thread only.
-
     class ShadowPassOperation final
     {
       public:
@@ -28,7 +26,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not take ownership of the supplied payload.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void execute(const std::any& payload);
 
         /// @brief
@@ -36,7 +33,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle managed by this pass.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         tbx::uint32 get_directional_shadow_texture() const;
 
         /// @brief
@@ -44,7 +40,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle managed by this pass.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         tbx::uint32 get_point_shadow_texture() const;
 
         /// @brief
@@ -52,7 +47,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle managed by this pass.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         tbx::uint32 get_spot_shadow_texture() const;
 
         /// @brief
@@ -60,7 +54,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Returns a non-owning OpenGL texture handle managed by this pass.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         tbx::uint32 get_area_shadow_texture() const;
 
       private:

--- a/plugins/opengl_rendering/src/pipeline/TransparentPassOperation.h
+++ b/plugins/opengl_rendering/src/pipeline/TransparentPassOperation.h
@@ -8,11 +8,9 @@ namespace opengl_rendering
 {
     /// @brief
     /// Purpose: Draws transparent surfaces into the resolved final-color target after lighting.
-
     /// @details
     /// Ownership: References shared render resources and the g-buffer owned by the renderer.
     /// Thread Safety: Not thread-safe; render-thread only.
-
     class TransparentPassOperation final
     {
       public:
@@ -28,7 +26,6 @@ namespace opengl_rendering
         /// @details
         /// Ownership: Does not take ownership of the supplied payload.
         /// Thread Safety: Not thread-safe; render-thread only.
-
         void execute(const std::any& payload);
 
       private:

--- a/plugins/sdl_opengl_adapter/include/tbx/plugins/sdl_opengl_adapter/sdl_open_gl_adapter.h
+++ b/plugins/sdl_opengl_adapter/include/tbx/plugins/sdl_opengl_adapter/sdl_open_gl_adapter.h
@@ -33,7 +33,7 @@ namespace sdl_opengl_adapter
     class TBX_PLUGIN_API SdlOpenGlAdapter final
     {
       public:
-        explicit SdlOpenGlAdapter(const SdlOpenGlAdapterSettings& settings);
+        SdlOpenGlAdapter(const SdlOpenGlAdapterSettings& settings);
         ~SdlOpenGlAdapter() noexcept;
 
         /// @brief
@@ -91,14 +91,14 @@ namespace sdl_opengl_adapter
         /// @details
         /// Ownership: Non-owning pointer; valid as long as SDL is available.
         /// Thread Safety: Safe to copy; invocation must obey SDL context thread rules.
-        [[nodiscard]] tbx::GraphicsProcAddress get_proc_address() const;
+        tbx::GraphicsProcAddress get_proc_address() const;
 
         /// @brief
         /// Purpose: Allows callers to validate context availability.
         /// @details
         /// Ownership: Non-owning window pointer.
         /// Thread Safety: Not thread-safe; call on owning thread.
-        [[nodiscard]] bool has_context(SDL_Window* sdl_window) const;
+        bool has_context(SDL_Window* sdl_window) const;
 
       private:
         SdlOpenGlAdapterSettings _settings = {};

--- a/plugins/stb_image_loader/include/tbx/plugins/stb_image_loader/stb_image_loader_plugin.h
+++ b/plugins/stb_image_loader/include/tbx/plugins/stb_image_loader/stb_image_loader_plugin.h
@@ -9,42 +9,22 @@ namespace stb_image_loader
 {
     /// @brief
     /// Purpose: Loads texture assets into tbx::Texture payloads using stb_image.
-
     /// @details
     /// Ownership: tbx::Plugin lifetime is owned by the host; it keeps non-owning references to the
     /// host. Thread Safety: Handles asset messages on the dispatcher thread; no internal
     /// synchronization.
-
     class TBX_PLUGIN_API StbImageLoaderPlugin final : public tbx::Plugin
     {
       public:
-        /// @brief
-        /// Purpose: Captures host references needed for asset resolution.
-
-        /// @details
-        /// Ownership: Does not take ownership of the host.
-        /// Thread Safety: Called on the main thread during plugin attach.
-
         void on_attach(tbx::IPluginHost& host) override;
-
-        /// @brief
-        /// Purpose: Releases any cached host references.
-
-        /// @details
-        /// Ownership: Does not destroy host resources.
-        /// Thread Safety: Called on the main thread during plugin detach.
-
         void on_detach() override;
 
         /// @brief
         /// Purpose: Receives texture load requests and dispatches stb image loads.
-
-        /// @brief
-        /// Purpose: synchronization.
         /// @details
         /// Ownership: Does not take ownership of messages or asset payloads.
         /// Thread Safety: Executes on the dispatcher thread; relies on tbx::Texture payload
-
+        /// synchronization.
         void on_recieve_message(tbx::Message& msg) override;
 
       private:


### PR DESCRIPTION
### Motivation
- Provide a concise agent workflow and add a centralized `CodeStandard.md` for consistent C++ style and contributor expectations. 
- Normalize header layout, spacing, and comment placement across the codebase to reduce churn and make future reviews consistent. 
- Apply small API/constructor adjustments and fix a few test sources so they match the updated formatting and string quoting styles. 

### Description
- Add `CodeStandard.md` and replace the previous `AGENTS.md` with a focused `Toybox Agent Guide` that references the new code standard and documents agent workflow and testing guidance. 
- Reformat and normalize many public headers and plugin sources (includes, comment blocks, ordering, spacing) across modules (assets, async, common, ecs, files, graphics, input, math, messaging, physics, plugin_api, plugins, etc.). 
- Minor API signature/qualifier tweaks in a few locations (e.g., constructor/`explicit` usage removed in some shader classes, adjusted function declarations) and consistent placement of inline/templated utilities. 
- Update a handful of test sources and helpers to match the new formatting and in-memory file ops usage. 

### Testing
- Ran unit tests touching the modified areas: `modules/assets` unit tests (including `asset_meta_tests`) and `modules/plugin_api` unit tests (including `plugin_loader_tests`); these tests succeeded. 
- Performed a local build of the affected modules to verify headers and signatures remain coherent; build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8ff6aac008327a280542ff7166ea1)