### PR TITLE
Introduce RenderResourceManager and backend upload API; refactor OpenGL uploader and resource handling

### DIFF
--- a/modules/graphics/CMakeLists.txt
+++ b/modules/graphics/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Tbx::${module_name} ALIAS ${module_name})
 
 target_sources(${module_name} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/engine/graphics_render_pipeline.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/engine/graphics_render_resources.cpp
 )
 
 target_include_directories(${module_name}

--- a/modules/graphics/engine/graphics_render_pipeline.cpp
+++ b/modules/graphics/engine/graphics_render_pipeline.cpp
@@ -10,6 +10,7 @@
 #include "tbx/ecs/entity_registry.h"
 #include "tbx/graphics/frustum.h"
 #include "tbx/graphics/sphere.h"
+#include "tbx/graphics/render_resources.h"
 #include "tbx/math/matrices.h"
 #include "tbx/math/trig.h"
 #include <algorithm>
@@ -516,11 +517,11 @@ namespace tbx
                 const auto& sky = *scene.sky;
                 out_transparent_draws.push_back(
                     RenderDrawItem {
-                        .material = sky.material,
+                        .mesh_resource = sky.mesh_resource,
+                        .material_resource = sky.material_resource,
                         .material_config = sky.material_config,
                         .material_parameters = sky.material_parameters,
                         .material_textures = sky.material_textures,
-                        .mesh = DynamicMesh(std::make_shared<Mesh>(sky_dome)),
                         .transform = sky.transform,
                         .camera_distance_squared = sky.camera_distance_squared,
                     });
@@ -825,6 +826,7 @@ namespace tbx
         void collect_render_items(
             const EntityRegistry& entity_registry,
             AssetManager& asset_manager,
+            RenderResourceManager& resource_manager,
             RenderScene& scene)
         {
             if (!scene.has_camera)
@@ -852,6 +854,16 @@ namespace tbx
                 const auto camera_distance = sqrt(camera_distance_squared);
 
                 const auto mesh = resolve_render_mesh(entity, lods, camera_distance);
+                const auto mesh_resource = std::visit(
+                    [&resource_manager](const auto& mesh_value)
+                    {
+                        using TMesh = std::remove_cvref_t<decltype(mesh_value)>;
+                        if constexpr (std::is_same_v<TMesh, DynamicMesh>)
+                            return resource_manager.upload_dynamic_mesh(mesh_value);
+                        else
+                            return resource_manager.upload_static_mesh(mesh_value);
+                    },
+                    mesh);
 
                 Handle material_handle = material_instance->material;
                 if (material_handle.get_name().empty() && material_handle.get_id().is_valid())
@@ -861,7 +873,19 @@ namespace tbx
                 const auto material_config = resolve_material_config(*material_instance, material_asset);
                 const auto material_parameters =
                     resolve_material_parameters(*material_instance, material_asset);
-                const auto material_textures = resolve_material_textures(*material_instance, material_asset);
+                auto material_textures = resolve_material_textures(*material_instance, material_asset);
+                for (auto& texture_binding : material_textures.values)
+                {
+                    if (!texture_binding.texture.handle.is_valid())
+                        continue;
+
+                    const auto texture_resource =
+                        resource_manager.upload_texture(texture_binding.texture.handle);
+                    texture_binding.texture.handle = Handle(
+                        texture_binding.texture.handle.get_name(),
+                        texture_resource);
+                }
+                const auto material_resource = resource_manager.upload_material(*material_instance);
                 const auto casts_shadows = material_config.shadow_mode != ShadowMode::None;
 
                 if (lods != nullptr && lods->render_distance > 0.0F
@@ -881,7 +905,7 @@ namespace tbx
                 {
                     scene.shadow_items.push_back(
                         RenderShadowItem {
-                            .mesh = mesh,
+                            .mesh_resource = mesh_resource,
                             .transform = build_transform_matrix(world_transform),
                             .bounds_radius = bounds_radius,
                             .is_two_sided = material_config.is_two_sided,
@@ -892,11 +916,11 @@ namespace tbx
                 {
                     scene.draw_items.push_back(
                         RenderDrawItem {
-                            .material = *material_instance,
+                            .mesh_resource = mesh_resource,
+                            .material_resource = material_resource,
                             .material_config = material_config,
                             .material_parameters = material_parameters,
                             .material_textures = material_textures,
-                            .mesh = mesh,
                             .transform = build_transform_matrix(world_transform),
                             .camera_distance_squared = camera_distance_squared,
                         });
@@ -951,6 +975,23 @@ namespace tbx
                     }
                 }
 
+                for (auto& texture_binding : material_textures.values)
+                {
+                    if (!texture_binding.texture.handle.is_valid())
+                        continue;
+
+                    const auto texture_resource =
+                        resource_manager.upload_texture(texture_binding.texture.handle);
+                    texture_binding.texture.handle = Handle(
+                        texture_binding.texture.handle.get_name(),
+                        texture_resource);
+                }
+
+                const auto sky_material_resource = resource_manager.upload_material(sky_material_instance);
+                const auto sky_mesh_resource = resource_manager.upload_dynamic_mesh(
+                    DynamicMesh(std::make_shared<Mesh>(sky_dome)),
+                    true);
+
                 auto sky_transform = sky_entity.has_component<Transform>()
                                          ? get_world_space_transform(sky_entity)
                                          : Transform();
@@ -961,7 +1002,8 @@ namespace tbx
                 sky_transform.scale = Vec3(sky_scale, sky_scale, sky_scale);
 
                 scene.sky = RenderSky {
-                    .material = sky_material_instance,
+                    .mesh_resource = sky_mesh_resource,
+                    .material_resource = sky_material_resource,
                     .material_config = material_config,
                     .material_parameters = material_parameters,
                     .material_textures = material_textures,
@@ -975,6 +1017,7 @@ namespace tbx
         RenderScene build_scene(
             const EntityRegistry& entity_registry,
             AssetManager& asset_manager,
+            RenderResourceManager& resource_manager,
             const GraphicsSettings& settings,
             const Size& viewport_size,
             bool& has_reported_missing_camera)
@@ -1022,7 +1065,7 @@ namespace tbx
             build_light_data(entity_registry, scene);
             build_shadow_data(settings, scene);
             build_post_processing_data(entity_registry, scene);
-            collect_render_items(entity_registry, asset_manager, scene);
+            collect_render_items(entity_registry, asset_manager, resource_manager, scene);
             return scene;
         }
     }
@@ -1046,6 +1089,7 @@ namespace tbx
         , _window_manager(window_manager)
         , _context_manager(context_manager)
         , _backend(backend)
+        , _resource_manager(std::make_unique<RenderResourceManager>(_asset_manager, _backend))
     {
         _thread_manager.try_create_lane(RenderLaneName);
         _message_handler_token = _message_coordinator.register_handler(
@@ -1127,6 +1171,7 @@ namespace tbx
                         const auto scene = build_scene(
                             _entity_registry,
                             _asset_manager,
+                            *_resource_manager,
                             _settings,
                             viewport_size,
                             _has_reported_missing_camera);
@@ -1134,6 +1179,8 @@ namespace tbx
                         auto opaque_draws = std::vector<RenderDrawItem> {};
                         auto transparent_draws = std::vector<RenderDrawItem> {};
                         split_draw_items(scene, opaque_draws, transparent_draws);
+
+                        const auto shadow_info = build_shadow_render_info(scene);
 
                         if (const auto begin_draw_result = _backend.begin_draw(
                                 window,
@@ -1163,7 +1210,7 @@ namespace tbx
 
                         execute_pass(
                             "shadow pass",
-                            _backend.draw_shadows(build_shadow_render_info(scene)));
+                            _backend.draw_shadows(shadow_info));
                         execute_pass(
                             "geometry pass",
                             _backend.draw_geometry(
@@ -1202,6 +1249,8 @@ namespace tbx
                                 to_string(window),
                                 present_result.get_report());
                         }
+
+                        _resource_manager->clear_unused();
                     })
                 .get();
         }
@@ -1227,7 +1276,7 @@ namespace tbx
                 [this, reloaded_assets = std::move(reloaded_assets)]() mutable
                 {
                     for (const auto& handle : reloaded_assets)
-                        _backend.on_asset_reloaded(handle);
+                        _resource_manager->on_asset_reloaded(handle);
                 })
             .get();
     }

--- a/modules/graphics/engine/graphics_render_resources.cpp
+++ b/modules/graphics/engine/graphics_render_resources.cpp
@@ -398,7 +398,7 @@ namespace tbx
     {
     }
 
-    Uuid RenderResourceManager::add_dynamic_mesh(const DynamicMesh& dynamic_mesh, const bool pin)
+    Uuid RenderResourceManager::upload_dynamic_mesh(const DynamicMesh& dynamic_mesh, const bool pin)
     {
         const auto now = std::chrono::steady_clock::now();
         const auto key = make_dynamic_mesh_key(dynamic_mesh.data);
@@ -442,7 +442,7 @@ namespace tbx
         }
 
         auto backend_resource_uuid = Uuid {};
-        const auto create_result = _backend.try_upload(*dynamic_mesh.data, backend_resource_uuid);
+        const auto create_result = _backend.upload(*dynamic_mesh.data, backend_resource_uuid);
         if (!create_result || !backend_resource_uuid.is_valid())
             return {};
 
@@ -456,7 +456,7 @@ namespace tbx
         return backend_resource_uuid;
     }
 
-    Uuid RenderResourceManager::add_static_mesh(const StaticMesh& static_mesh, const bool pin)
+    Uuid RenderResourceManager::upload_static_mesh(const StaticMesh& static_mesh, const bool pin)
     {
         const auto now = std::chrono::steady_clock::now();
         const auto resolved_mesh_handle = resolve_asset_handle(static_mesh.handle, _asset_manager);
@@ -486,7 +486,7 @@ namespace tbx
         }
 
         auto backend_resource_uuid = Uuid {};
-        const auto create_result = _backend.try_upload(render_mesh, backend_resource_uuid);
+        const auto create_result = _backend.upload(render_mesh, backend_resource_uuid);
         if (!create_result || !backend_resource_uuid.is_valid())
             return {};
 
@@ -499,7 +499,7 @@ namespace tbx
         return backend_resource_uuid;
     }
 
-    Uuid RenderResourceManager::add_material(
+    Uuid RenderResourceManager::upload_material(
         const MaterialInstance& material_instance,
         const bool pin)
     {
@@ -534,8 +534,7 @@ namespace tbx
                 material->program.geometry,
             };
             auto backend_resource_uuid = Uuid {};
-            const auto create_result =
-                _backend.try_upload(resolved_material_handle, *material, backend_resource_uuid);
+            const auto create_result = _backend.upload(*material, backend_resource_uuid);
             if (create_result && backend_resource_uuid.is_valid())
             {
                 _resources.insert(program_key);
@@ -588,7 +587,7 @@ namespace tbx
         return material;
     }
 
-    Uuid RenderResourceManager::add_texture(
+    Uuid RenderResourceManager::upload_texture(
         const Texture& texture,
         const Uuid& resource_uuid,
         const bool pin)
@@ -610,7 +609,7 @@ namespace tbx
         }
 
         auto backend_resource_uuid = Uuid {};
-        const auto create_result = _backend.try_upload(texture, backend_resource_uuid);
+        const auto create_result = _backend.upload(texture, backend_resource_uuid);
         if (!create_result || !backend_resource_uuid.is_valid())
             return {};
 
@@ -623,16 +622,11 @@ namespace tbx
         return backend_resource_uuid;
     }
 
-    Uuid RenderResourceManager::add_render_texture(
+    Uuid RenderResourceManager::upload_render_texture(
         const TextureSettings& texture_settings,
-        const Uuid& resource_uuid,
         const bool pin)
     {
-        auto resolved_resource_uuid = resource_uuid;
-        if (!resolved_resource_uuid.is_valid())
-            resolved_resource_uuid = Uuid::generate();
-
-        const auto key = make_render_texture_key(resolved_resource_uuid);
+        const auto key = make_render_texture_key(Uuid::generate());
         if (!key.is_valid())
             return {};
 
@@ -646,7 +640,7 @@ namespace tbx
         }
 
         auto backend_resource_uuid = Uuid {};
-        const auto create_result = _backend.try_upload(texture_settings, backend_resource_uuid);
+        const auto create_result = _backend.upload(texture_settings, backend_resource_uuid);
         if (!create_result || !backend_resource_uuid.is_valid())
             return {};
 
@@ -659,7 +653,7 @@ namespace tbx
         return backend_resource_uuid;
     }
 
-    Uuid RenderResourceManager::add_texture(const Handle& texture_handle, const bool pin)
+    Uuid RenderResourceManager::upload_texture(const Handle& texture_handle, const bool pin)
     {
         const auto resolved_texture_handle = resolve_asset_handle(texture_handle, _asset_manager);
         const auto key = make_texture_key(resolved_texture_handle);
@@ -680,7 +674,7 @@ namespace tbx
             return {};
 
         auto backend_resource_uuid = Uuid {};
-        const auto create_result = _backend.try_upload(*texture, backend_resource_uuid);
+        const auto create_result = _backend.upload(*texture, backend_resource_uuid);
         if (!create_result || !backend_resource_uuid.is_valid())
             return {};
 
@@ -693,7 +687,7 @@ namespace tbx
         return backend_resource_uuid;
     }
 
-    void RenderResourceManager::destroy(const Uuid& resource_uuid)
+    void RenderResourceManager::unload(const Uuid& resource_uuid)
     {
         invalidate_resource(resolve_resource_key(resource_uuid));
     }
@@ -749,7 +743,7 @@ namespace tbx
         if (!backend_resource_uuid.is_valid())
             return;
 
-        const auto destroy_result = _backend.try_unload(backend_resource_uuid);
+        const auto destroy_result = _backend.unload(backend_resource_uuid);
         if (!destroy_result)
         {
             TBX_TRACE_WARNING(

--- a/modules/graphics/include/tbx/graphics/render_pipeline.h
+++ b/modules/graphics/include/tbx/graphics/render_pipeline.h
@@ -8,6 +8,7 @@
 #include "tbx/graphics/material.h"
 #include "tbx/graphics/mesh.h"
 #include "tbx/graphics/post_processing.h"
+#include "tbx/graphics/render_resources.h"
 #include "tbx/graphics/renderer.h"
 #include "tbx/graphics/settings.h"
 #include "tbx/graphics/window.h"
@@ -50,18 +51,18 @@ namespace tbx
 
     struct TBX_API RenderDrawItem
     {
-        MaterialInstance material = {};
+        Uuid mesh_resource = {};
+        Uuid material_resource = {};
         MaterialConfig material_config = {};
         ParamBindings material_parameters = {};
         TextureBindings material_textures = {};
-        RenderMesh mesh = StaticMesh();
         Mat4 transform = Mat4(1.0F);
         float camera_distance_squared = 0.0F;
     };
 
     struct TBX_API RenderShadowItem
     {
-        RenderMesh mesh = StaticMesh();
+        Uuid mesh_resource = {};
         Mat4 transform = Mat4(1.0F);
         float bounds_radius = 0.0F;
         bool is_two_sided = false;
@@ -69,7 +70,8 @@ namespace tbx
 
     struct TBX_API RenderSky
     {
-        MaterialInstance material = {};
+        Uuid mesh_resource = {};
+        Uuid material_resource = {};
         MaterialConfig material_config = {};
         ParamBindings material_parameters = {};
         TextureBindings material_textures = {};
@@ -217,7 +219,13 @@ namespace tbx
       public:
         virtual GraphicsApi get_api() const = 0;
         virtual Result initialize(GraphicsProcAddress loader) = 0;
-        virtual void on_asset_reloaded(const Handle& asset_handle) = 0;
+        virtual Result upload(const Mesh& mesh, Uuid& out_resource_uuid) = 0;
+        virtual Result upload(const Material& material, Uuid& out_resource_uuid) = 0;
+        virtual Result upload(const Texture& texture, Uuid& out_resource_uuid) = 0;
+        virtual Result upload(
+            const TextureSettings& texture_settings,
+            Uuid& out_resource_uuid) = 0;
+        virtual Result unload(const Uuid& resource_uuid) = 0;
         virtual Result begin_draw(
             const Window& window,
             const Camera& view,
@@ -271,6 +279,7 @@ namespace tbx
         IWindowManager& _window_manager;
         IGraphicsContextManager& _context_manager;
         IGraphicsBackend& _backend;
+        std::unique_ptr<RenderResourceManager> _resource_manager = nullptr;
         Uuid _message_handler_token = {};
         bool _is_backend_initialized = false;
         std::unordered_map<Window, Size> _windows = {};

--- a/modules/graphics/include/tbx/graphics/render_resources.h
+++ b/modules/graphics/include/tbx/graphics/render_resources.h
@@ -39,5 +39,30 @@ namespace tbx
         void unpin(const Uuid& resource_uuid);
         void clear();
         void clear_unused();
+
+      private:
+        void invalidate_material_program(const Uuid& program_key);
+        void invalidate_resource(const Uuid& resource_key);
+        void destroy_backend_resource(const Uuid& resource_key);
+        void clear_shader_dependencies(const Uuid& program_key);
+        void store_shader_dependencies(
+            const Uuid& program_key,
+            const std::vector<Handle>& shader_handles);
+        std::shared_ptr<Material> get_material_asset(const Handle& material_handle);
+        Uuid get_backend_resource_uuid(const Uuid& resource_key) const;
+        Uuid resolve_resource_key(const Uuid& resource_uuid) const;
+
+      private:
+        AssetManager& _asset_manager;
+        IGraphicsBackend& _backend;
+        std::unordered_set<Uuid> _resources = {};
+        std::unordered_map<Uuid, Uuid> _backend_resources = {};
+        std::unordered_map<Uuid, Uuid> _resource_keys_by_backend = {};
+        std::unordered_map<Uuid, std::weak_ptr<Mesh>> _dynamic_mesh_sources = {};
+        std::unordered_map<Uuid, std::shared_ptr<Material>> _material_assets = {};
+        std::unordered_set<Uuid> _pinned_resources = {};
+        std::unordered_map<Uuid, std::chrono::steady_clock::time_point> _last_access = {};
+        std::unordered_map<Uuid, std::vector<Uuid>> _programs_by_shader = {};
+        std::unordered_map<Uuid, std::vector<Uuid>> _shaders_by_program = {};
     };
 }

--- a/plugins/opengl_rendering/src/opengl_fallbacks.cpp
+++ b/plugins/opengl_rendering/src/opengl_fallbacks.cpp
@@ -1,5 +1,5 @@
 #include "opengl_fallbacks.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "tbx/debugging/macros.h"
 
 namespace opengl_rendering
@@ -86,7 +86,7 @@ namespace opengl_rendering
         return shader_sources;
     }
 
-    tbx::Uuid get_fallback_texture(OpenGlResourceManager& resource_manager)
+    tbx::Uuid get_fallback_texture(OpenGlUploader& resource_manager)
     {
         return resource_manager.add_texture(
             get_fallback_texture(),
@@ -94,7 +94,7 @@ namespace opengl_rendering
             true);
     }
 
-    tbx::Uuid get_flat_normal_texture(OpenGlResourceManager& resource_manager)
+    tbx::Uuid get_flat_normal_texture(OpenGlUploader& resource_manager)
     {
         return resource_manager.add_texture(
             get_flat_normal_texture_data(),
@@ -102,7 +102,7 @@ namespace opengl_rendering
             true);
     }
 
-    tbx::Uuid get_fallback_material(OpenGlResourceManager& resource_manager)
+    tbx::Uuid get_fallback_material(OpenGlUploader& resource_manager)
     {
         auto existing_program = std::shared_ptr<OpenGlShaderProgram> {};
         const auto fallback_program_id = get_fallback_material_resource_id();

--- a/plugins/opengl_rendering/src/opengl_fallbacks.h
+++ b/plugins/opengl_rendering/src/opengl_fallbacks.h
@@ -3,14 +3,14 @@
 
 namespace opengl_rendering
 {
-    class OpenGlResourceManager;
+    class OpenGlUploader;
 
     OpenGlMaterialParams create_magenta_fallback_material_params(
         const tbx::Handle& material_handle);
     const tbx::Uuid& get_fallback_texture_resource_id();
-    tbx::Uuid get_fallback_texture(OpenGlResourceManager& resource_manager);
+    tbx::Uuid get_fallback_texture(OpenGlUploader& resource_manager);
     const tbx::Uuid& get_flat_normal_texture_resource_id();
-    tbx::Uuid get_flat_normal_texture(OpenGlResourceManager& resource_manager);
+    tbx::Uuid get_flat_normal_texture(OpenGlUploader& resource_manager);
     const tbx::Uuid& get_fallback_material_resource_id();
-    tbx::Uuid get_fallback_material(OpenGlResourceManager& resource_manager);
+    tbx::Uuid get_fallback_material(OpenGlUploader& resource_manager);
 }

--- a/plugins/opengl_rendering/src/opengl_renderer.cpp
+++ b/plugins/opengl_rendering/src/opengl_renderer.cpp
@@ -87,35 +87,16 @@ namespace opengl_rendering
                 renderer_text);
         }
 
-        tbx::Uuid resolve_mesh_key_for_render_mesh(
-            const tbx::RenderMesh& mesh,
-            OpenGlResourceManager& resource_manager)
-        {
-            return std::visit(
-                [&resource_manager](const auto& mesh_value)
-                {
-                    using TMesh = std::remove_cvref_t<decltype(mesh_value)>;
-                    if constexpr (std::is_same_v<TMesh, tbx::DynamicMesh>)
-                        return resource_manager.add_dynamic_mesh(mesh_value);
-                    else
-                        return resource_manager.add_static_mesh(mesh_value);
-                },
-                mesh);
-        }
-
         tbx::Uuid resolve_shader_program_for_material(
-            const tbx::MaterialInstance& material_instance,
-            OpenGlResourceManager& resource_manager,
+            const tbx::Uuid& material_resource,
+            OpenGlUploader& resource_manager,
             bool& use_fallback_material_params)
         {
             use_fallback_material_params = false;
-            auto shader_program_key = resource_manager.add_material(material_instance);
+            auto shader_program_key = material_resource;
             if (shader_program_key.is_valid())
                 return shader_program_key;
 
-            TBX_TRACE_WARNING(
-                "Failed to cache shader program for material '{}'. Using fallback magenta material.",
-                material_instance.material.get_id().value);
             shader_program_key = get_fallback_material(resource_manager);
             use_fallback_material_params = true;
             if (shader_program_key.is_valid())
@@ -127,7 +108,7 @@ namespace opengl_rendering
 
         tbx::Uuid get_default_texture_for_binding(
             std::string_view binding_name,
-            OpenGlResourceManager& resource_manager)
+            OpenGlUploader& resource_manager)
         {
             if (binding_name == "u_normal_map")
                 return get_flat_normal_texture(resource_manager);
@@ -144,23 +125,16 @@ namespace opengl_rendering
             OpenGlMaterialParams& material_params,
             const std::string& binding_name,
             const tbx::TextureInstance& texture_instance,
-            const tbx::Handle& material_handle,
-            OpenGlResourceManager& resource_manager)
+            OpenGlUploader& resource_manager)
         {
             auto texture_id = tbx::Uuid {};
             if (texture_instance.handle.is_valid())
-                texture_id = resource_manager.add_texture(texture_instance.handle);
+                texture_id = texture_instance.handle.get_id();
             else
                 texture_id = get_default_texture_for_binding(binding_name, resource_manager);
 
             if (!texture_id.is_valid())
-            {
-                TBX_TRACE_WARNING(
-                    "Failed to cache texture '{}' for material '{}'. Using fallback texture.",
-                    texture_instance.handle.get_id().value,
-                    material_handle.get_id().value);
                 texture_id = get_default_texture_for_binding(binding_name, resource_manager);
-            }
 
             if (!texture_id.is_valid())
                 return false;
@@ -169,10 +143,8 @@ namespace opengl_rendering
             if (!resource_manager.try_get<OpenGlTexture>(texture_id, texture_resource))
             {
                 TBX_TRACE_WARNING(
-                    "Failed to fetch texture resource '{}' for material '{}'. Using fallback "
-                    "texture.",
-                    texture_id.value,
-                    material_handle.get_id().value);
+                    "Failed to fetch texture resource '{}'. Using fallback texture.",
+                    texture_id.value);
                 return false;
             }
 
@@ -188,7 +160,7 @@ namespace opengl_rendering
 
         void append_default_material_texture_if_needed(
             OpenGlMaterialParams& material_params,
-            OpenGlResourceManager& resource_manager)
+            OpenGlUploader& resource_manager)
         {
             if (!material_params.textures.empty())
                 return;
@@ -211,21 +183,21 @@ namespace opengl_rendering
         }
 
         OpenGlMaterialParams build_material_params(
-            const tbx::MaterialInstance& material_instance,
+            const tbx::Uuid& material_resource,
             const tbx::MaterialConfig& material_config,
             const tbx::ParamBindings& material_parameters,
             const tbx::TextureBindings& material_textures,
             const bool use_fallback_material_params,
-            OpenGlResourceManager& resource_manager)
+            OpenGlUploader& resource_manager)
         {
             auto material_params = OpenGlMaterialParams {};
             if (use_fallback_material_params)
             {
-                material_params = create_magenta_fallback_material_params(material_instance.material);
+                material_params = create_magenta_fallback_material_params(tbx::Handle(material_resource));
             }
             else
             {
-                material_params.material_handle = material_instance.material;
+                material_params.material_handle = tbx::Handle(material_resource);
                 material_params.parameters.reserve(material_parameters.values.size());
                 for (const auto& [name, value] : material_parameters.values)
                     material_params.parameters.push_back(tbx::MaterialParameter(name, value));
@@ -243,7 +215,6 @@ namespace opengl_rendering
                     material_params,
                     binding.name,
                     binding.texture,
-                    material_instance.material,
                     resource_manager);
             }
 
@@ -335,21 +306,19 @@ namespace opengl_rendering
     struct OpenGlWindowRendererState
     {
         OpenGlWindowRendererState(
-            tbx::AssetManager& asset_manager,
+            OpenGlUploader& resource_manager,
             tbx::JobSystem& job_system,
-            const std::size_t initial_asset_reload_count)
-            : resource_manager(asset_manager)
-            , shadow_pass(std::make_unique<ShadowPass>(resource_manager))
+            const tbx::Size& initial_render_size)
+            : shadow_pass(std::make_unique<ShadowPass>(resource_manager))
             , geometry_pass(std::make_unique<GeometryPass>(resource_manager))
             , lighting_pass(
                   std::make_unique<LightingPass>(resource_manager, job_system, gbuffer, *shadow_pass))
             , transparent_pass(std::make_unique<TransparentPass>(resource_manager, gbuffer))
             , post_processing_pass(std::make_unique<PostProcessingPass>(resource_manager, gbuffer))
-            , processed_asset_reload_count(initial_asset_reload_count)
         {
+            render_size = initial_render_size;
         }
 
-        OpenGlResourceManager resource_manager;
         OpenGlGBuffer gbuffer = {};
         std::unique_ptr<ShadowPass> shadow_pass = nullptr;
         std::unique_ptr<GeometryPass> geometry_pass = nullptr;
@@ -363,13 +332,13 @@ namespace opengl_rendering
         std::vector<DrawCall> draw_calls = {};
         std::vector<ShadowDrawCall> shadow_draw_calls = {};
         std::vector<TransparentDrawCall> transparent_draw_calls = {};
-        std::size_t processed_asset_reload_count = 0U;
         bool has_reported_pipeline_failure = false;
     };
 
     OpenGlRenderer::OpenGlRenderer(tbx::AssetManager& asset_manager, tbx::JobSystem& job_system)
         : _asset_manager(asset_manager)
         , _job_system(job_system)
+        , _resource_manager(_asset_manager)
     {
     }
 
@@ -386,12 +355,103 @@ namespace opengl_rendering
         return {};
     }
 
-    void OpenGlRenderer::on_asset_reloaded(const tbx::Handle& asset_handle)
+    tbx::Result OpenGlRenderer::upload(const tbx::Mesh& mesh, tbx::Uuid& out_resource_uuid)
     {
-        if (!asset_handle.get_id().is_valid())
-            return;
+        auto resource_uuid = out_resource_uuid;
+        if (!resource_uuid.is_valid())
+            resource_uuid = tbx::Uuid::generate();
+        const auto uploaded_resource_uuid = _resource_manager.add_mesh(mesh, resource_uuid);
+        if (!uploaded_resource_uuid.is_valid())
+            return tbx::Result(false, "OpenGL rendering: failed to upload mesh resource.");
 
-        _asset_reload_events.push_back(asset_handle);
+        out_resource_uuid = uploaded_resource_uuid;
+        return {};
+    }
+
+    tbx::Result OpenGlRenderer::upload(const tbx::Material& material, tbx::Uuid& out_resource_uuid)
+    {
+        auto shader_resources = std::vector<std::shared_ptr<OpenGlShader>> {};
+        auto try_append_shader = [this, &shader_resources](const tbx::Handle& shader_handle)
+        {
+            if (!shader_handle.is_valid())
+                return true;
+
+            const auto shader = _asset_manager.load<tbx::Shader>(shader_handle);
+            if (!shader)
+                return false;
+
+            for (const auto& source : shader->sources)
+            {
+                auto shader_resource = std::make_shared<OpenGlShader>(source);
+                if (!shader_resource->compile())
+                    return false;
+                shader_resources.emplace_back(std::move(shader_resource));
+            }
+
+            return !shader->sources.empty();
+        };
+
+        const auto has_compute = material.program.compute.is_valid();
+        const auto appended_compute = try_append_shader(material.program.compute);
+        const auto appended_vertex = has_compute ? true : try_append_shader(material.program.vertex);
+        const auto appended_fragment = has_compute ? true : try_append_shader(material.program.fragment);
+        const auto appended_tesselation =
+            has_compute ? true : try_append_shader(material.program.tesselation);
+        const auto appended_geometry =
+            has_compute ? true : try_append_shader(material.program.geometry);
+        const auto has_valid_shader_set =
+            (has_compute && appended_compute)
+            || (!has_compute && appended_vertex && appended_fragment && appended_tesselation
+                && appended_geometry);
+        if (!has_valid_shader_set)
+            return tbx::Result(false, "OpenGL rendering: failed to compile material shader set.");
+
+        const auto shader_program = std::make_shared<OpenGlShaderProgram>(shader_resources);
+        if (shader_program->get_program_id() == 0)
+            return tbx::Result(false, "OpenGL rendering: failed to link shader program.");
+
+        auto resource_uuid = out_resource_uuid;
+        if (!resource_uuid.is_valid())
+            resource_uuid = tbx::Uuid::generate();
+        const auto uploaded_resource_uuid =
+            _resource_manager.add_material(shader_program, resource_uuid);
+        if (!uploaded_resource_uuid.is_valid())
+            return tbx::Result(false, "OpenGL rendering: failed to upload material resource.");
+
+        out_resource_uuid = uploaded_resource_uuid;
+        return {};
+    }
+
+    tbx::Result OpenGlRenderer::upload(const tbx::Texture& texture, tbx::Uuid& out_resource_uuid)
+    {
+        const auto resource_uuid = out_resource_uuid.is_valid() ? out_resource_uuid : tbx::Uuid::generate();
+        const auto uploaded_resource_uuid = _resource_manager.add_texture(texture, resource_uuid);
+        if (!uploaded_resource_uuid.is_valid())
+            return tbx::Result(false, "OpenGL rendering: failed to upload texture resource.");
+
+        out_resource_uuid = uploaded_resource_uuid;
+        return {};
+    }
+
+    tbx::Result OpenGlRenderer::upload(
+        const tbx::TextureSettings& texture_settings,
+        tbx::Uuid& out_resource_uuid)
+    {
+        const auto resource_uuid = out_resource_uuid.is_valid() ? out_resource_uuid : tbx::Uuid::generate();
+        auto texture = tbx::Texture {};
+        static_cast<tbx::TextureSettings&>(texture) = texture_settings;
+        const auto uploaded_resource_uuid = _resource_manager.add_texture(texture, resource_uuid);
+        if (!uploaded_resource_uuid.is_valid())
+            return tbx::Result(false, "OpenGL rendering: failed to upload render texture resource.");
+
+        out_resource_uuid = uploaded_resource_uuid;
+        return {};
+    }
+
+    tbx::Result OpenGlRenderer::unload(const tbx::Uuid& resource_uuid)
+    {
+        _resource_manager.remove(resource_uuid);
+        return {};
     }
 
     tbx::Result OpenGlRenderer::begin_draw(
@@ -400,10 +460,9 @@ namespace opengl_rendering
         const tbx::Size& resolution,
         const tbx::Color& clear_color)
     {
+        static_cast<void>(window);
         static_cast<void>(view);
-        auto& state = ensure_state(window);
-        _active_window = window;
-        apply_asset_reloads(state);
+        auto& state = ensure_state();
         state.clear_color = clear_color;
         state.render_size = resolution;
         state.render_stage = tbx::RenderStage::FINAL_COLOR;
@@ -510,45 +569,24 @@ namespace opengl_rendering
         state->draw_calls.clear();
         state->shadow_draw_calls.clear();
         state->transparent_draw_calls.clear();
-        _active_window = {};
         return {};
     }
 
-    OpenGlWindowRendererState& OpenGlRenderer::ensure_state(const tbx::Window& window)
+    OpenGlWindowRendererState& OpenGlRenderer::ensure_state()
     {
-        const auto state_it = _states.find(window);
-        if (state_it != _states.end())
-            return *state_it->second;
+        if (_state)
+            return *_state;
 
-        auto state = std::make_unique<OpenGlWindowRendererState>(
-            _asset_manager,
+        _state = std::make_shared<OpenGlWindowRendererState>(
+            _resource_manager,
             _job_system,
-            _asset_reload_events.size());
-        auto* state_ptr = state.get();
-        _states.emplace(window, std::move(state));
-        return *state_ptr;
+            tbx::Size {0U, 0U});
+        return *_state;
     }
 
     OpenGlWindowRendererState* OpenGlRenderer::try_get_active_state()
     {
-        if (!_active_window.is_valid())
-            return nullptr;
-
-        const auto state_it = _states.find(_active_window);
-        if (state_it == _states.end())
-            return nullptr;
-
-        return state_it->second.get();
-    }
-
-    void OpenGlRenderer::apply_asset_reloads(OpenGlWindowRendererState& state)
-    {
-        while (state.processed_asset_reload_count < _asset_reload_events.size())
-        {
-            state.resource_manager.on_asset_reloaded(
-                _asset_reload_events[state.processed_asset_reload_count]);
-            ++state.processed_asset_reload_count;
-        }
+        return _state.get();
     }
 
     void OpenGlRenderer::build_geometry_draw_calls(
@@ -565,23 +603,23 @@ namespace opengl_rendering
         {
             auto use_fallback_material_params = false;
             const auto shader_program_key = resolve_shader_program_for_material(
-                draw_item.material,
-                state.resource_manager,
+                draw_item.material_resource,
+                _resource_manager,
                 use_fallback_material_params);
             if (!shader_program_key.is_valid())
                 continue;
 
-            const auto mesh_key = resolve_mesh_key_for_render_mesh(draw_item.mesh, state.resource_manager);
+            const auto mesh_key = draw_item.mesh_resource;
             if (!mesh_key.is_valid())
                 continue;
 
             auto material_params = build_material_params(
-                draw_item.material,
+                draw_item.material_resource,
                 draw_item.material_config,
                 draw_item.material_parameters,
                 draw_item.material_textures,
                 use_fallback_material_params,
-                state.resource_manager);
+                _resource_manager);
 
             append_visible_draw_call(
                 state.draw_calls,
@@ -609,7 +647,7 @@ namespace opengl_rendering
 
         for (const auto& draw_item : draw_items)
         {
-            const auto mesh_key = resolve_mesh_key_for_render_mesh(draw_item.mesh, state.resource_manager);
+            const auto mesh_key = draw_item.mesh_resource;
             if (!mesh_key.is_valid())
                 continue;
 
@@ -636,23 +674,23 @@ namespace opengl_rendering
         {
             auto use_fallback_material_params = false;
             const auto shader_program_key = resolve_shader_program_for_material(
-                draw_item.material,
-                state.resource_manager,
+                draw_item.material_resource,
+                _resource_manager,
                 use_fallback_material_params);
             if (!shader_program_key.is_valid())
                 continue;
 
-            const auto mesh_key = resolve_mesh_key_for_render_mesh(draw_item.mesh, state.resource_manager);
+            const auto mesh_key = draw_item.mesh_resource;
             if (!mesh_key.is_valid())
                 continue;
 
             auto material_params = build_material_params(
-                draw_item.material,
+                draw_item.material_resource,
                 draw_item.material_config,
                 draw_item.material_parameters,
                 draw_item.material_textures,
                 use_fallback_material_params,
-                state.resource_manager);
+                _resource_manager);
 
             append_visible_draw_call(
                 state.draw_calls,

--- a/plugins/opengl_rendering/src/opengl_renderer.h
+++ b/plugins/opengl_rendering/src/opengl_renderer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "tbx/graphics/render_pipeline.h"
+#include "opengl_uploader.h"
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 namespace opengl_rendering
@@ -17,7 +17,13 @@ namespace opengl_rendering
       public:
         tbx::GraphicsApi get_api() const override;
         tbx::Result initialize(tbx::GraphicsProcAddress loader) override;
-        void on_asset_reloaded(const tbx::Handle& asset_handle) override;
+        tbx::Result upload(const tbx::Mesh& mesh, tbx::Uuid& out_resource_uuid) override;
+        tbx::Result upload(const tbx::Material& material, tbx::Uuid& out_resource_uuid) override;
+        tbx::Result upload(const tbx::Texture& texture, tbx::Uuid& out_resource_uuid) override;
+        tbx::Result upload(
+            const tbx::TextureSettings& texture_settings,
+            tbx::Uuid& out_resource_uuid) override;
+        tbx::Result unload(const tbx::Uuid& resource_uuid) override;
         tbx::Result begin_draw(
             const tbx::Window& window,
             const tbx::Camera& view,
@@ -31,9 +37,8 @@ namespace opengl_rendering
         tbx::Result end_draw() override;
 
       private:
-        OpenGlWindowRendererState& ensure_state(const tbx::Window& window);
+        OpenGlWindowRendererState& ensure_state();
         OpenGlWindowRendererState* try_get_active_state();
-        void apply_asset_reloads(OpenGlWindowRendererState& state);
         void build_geometry_draw_calls(
             OpenGlWindowRendererState& state,
             const std::vector<tbx::RenderDrawItem>& draw_items);
@@ -48,9 +53,8 @@ namespace opengl_rendering
       private:
         tbx::AssetManager& _asset_manager;
         tbx::JobSystem& _job_system;
-        std::unordered_map<tbx::Window, std::unique_ptr<OpenGlWindowRendererState>> _states = {};
-        std::vector<tbx::Handle> _asset_reload_events = {};
-        tbx::Window _active_window = {};
+        OpenGlUploader _resource_manager;
+        std::shared_ptr<OpenGlWindowRendererState> _state = nullptr;
         bool _is_runtime_initialized = false;
     };
 }

--- a/plugins/opengl_rendering/src/opengl_uploader.cpp
+++ b/plugins/opengl_rendering/src/opengl_uploader.cpp
@@ -1,7 +1,7 @@
-#include "opengl_resource_manager.h"
-#include "opengl_mesh.h"
-#include "opengl_shader.h"
-#include "opengl_texture.h"
+#include "opengl_uploader.h"
+#include "opengl_resources/opengl_mesh.h"
+#include "opengl_resources/opengl_shader.h"
+#include "opengl_resources/opengl_texture.h"
 #include "tbx/debugging/macros.h"
 #include "tbx/graphics/material.h"
 #include "tbx/graphics/mesh.h"
@@ -390,12 +390,12 @@ namespace opengl_rendering
         return true;
     }
 
-    OpenGlResourceManager::OpenGlResourceManager(tbx::AssetManager& asset_manager)
+    OpenGlUploader::OpenGlUploader(tbx::AssetManager& asset_manager)
         : _asset_manager(asset_manager)
     {
     }
 
-    tbx::Uuid OpenGlResourceManager::add_dynamic_mesh(
+    tbx::Uuid OpenGlUploader::add_dynamic_mesh(
         const tbx::DynamicMesh& dynamic_mesh,
         const bool pin)
     {
@@ -451,7 +451,32 @@ namespace opengl_rendering
         return key;
     }
 
-    tbx::Uuid OpenGlResourceManager::add_static_mesh(
+    tbx::Uuid OpenGlUploader::add_mesh(
+        const tbx::Mesh& mesh,
+        const tbx::Uuid& resource_uuid,
+        const bool pin)
+    {
+        if (!resource_uuid.is_valid())
+            return {};
+
+        const auto now = std::chrono::steady_clock::now();
+        if (const auto existing = _resources.find(resource_uuid); existing != _resources.end())
+        {
+            _last_access.insert_or_assign(resource_uuid, now);
+            if (pin)
+                _pinned_resources.insert_or_assign(resource_uuid, existing->second);
+            return resource_uuid;
+        }
+
+        const auto resource = std::shared_ptr<IOpenGlResource>(std::make_shared<OpenGlMesh>(mesh));
+        _resources.insert_or_assign(resource_uuid, resource);
+        _last_access.insert_or_assign(resource_uuid, now);
+        if (pin)
+            _pinned_resources.insert_or_assign(resource_uuid, resource);
+        return resource_uuid;
+    }
+
+    tbx::Uuid OpenGlUploader::add_static_mesh(
         const tbx::StaticMesh& static_mesh,
         const bool pin)
     {
@@ -491,7 +516,7 @@ namespace opengl_rendering
         return key;
     }
 
-    tbx::Uuid OpenGlResourceManager::add_material(
+    tbx::Uuid OpenGlUploader::add_material(
         const tbx::MaterialInstance& material_instance,
         const bool pin)
     {
@@ -610,7 +635,7 @@ namespace opengl_rendering
         return {};
     }
 
-    std::shared_ptr<tbx::Material> OpenGlResourceManager::get_material_asset(
+    std::shared_ptr<tbx::Material> OpenGlUploader::get_material_asset(
         const tbx::Handle& material_handle)
     {
         const auto resolved_material_handle = resolve_asset_handle(material_handle, _asset_manager);
@@ -632,7 +657,7 @@ namespace opengl_rendering
         return material;
     }
 
-    tbx::Uuid OpenGlResourceManager::add_material(
+    tbx::Uuid OpenGlUploader::add_material(
         const std::shared_ptr<OpenGlShaderProgram>& shader_program,
         const tbx::Uuid& resource_uuid,
         const bool pin)
@@ -660,7 +685,7 @@ namespace opengl_rendering
         return resource_uuid;
     }
 
-    tbx::Uuid OpenGlResourceManager::add_texture(
+    tbx::Uuid OpenGlUploader::add_texture(
         const tbx::Texture& texture,
         const tbx::Uuid& resource_uuid,
         const bool pin)
@@ -686,7 +711,7 @@ namespace opengl_rendering
         return resource_uuid;
     }
 
-    tbx::Uuid OpenGlResourceManager::add_texture(const tbx::Handle& texture_handle, const bool pin)
+    tbx::Uuid OpenGlUploader::add_texture(const tbx::Handle& texture_handle, const bool pin)
     {
         const auto resolved_texture_handle = resolve_asset_handle(texture_handle, _asset_manager);
         const auto key = make_texture_key(resolved_texture_handle);
@@ -715,7 +740,7 @@ namespace opengl_rendering
         return key;
     }
 
-    void OpenGlResourceManager::on_asset_reloaded(const tbx::Handle& asset_handle)
+    void OpenGlUploader::on_asset_reloaded(const tbx::Handle& asset_handle)
     {
         if (!asset_handle.get_id().is_valid())
             return;
@@ -733,7 +758,7 @@ namespace opengl_rendering
             invalidate_material_program(program_key);
     }
 
-    void OpenGlResourceManager::invalidate_material_program(const tbx::Uuid& program_key)
+    void OpenGlUploader::invalidate_material_program(const tbx::Uuid& program_key)
     {
         if (!program_key.is_valid())
             return;
@@ -743,7 +768,7 @@ namespace opengl_rendering
         invalidate_resource(program_key);
     }
 
-    void OpenGlResourceManager::invalidate_resource(const tbx::Uuid& resource_uuid)
+    void OpenGlUploader::invalidate_resource(const tbx::Uuid& resource_uuid)
     {
         if (!resource_uuid.is_valid())
             return;
@@ -753,7 +778,7 @@ namespace opengl_rendering
         _last_access.erase(resource_uuid);
     }
 
-    void OpenGlResourceManager::clear_shader_dependencies(const tbx::Uuid& program_key)
+    void OpenGlUploader::clear_shader_dependencies(const tbx::Uuid& program_key)
     {
         const auto shader_list_iterator = _shaders_by_program.find(program_key);
         if (shader_list_iterator == _shaders_by_program.end())
@@ -774,7 +799,7 @@ namespace opengl_rendering
         _shaders_by_program.erase(shader_list_iterator);
     }
 
-    void OpenGlResourceManager::store_shader_dependencies(
+    void OpenGlUploader::store_shader_dependencies(
         const tbx::Uuid& program_key,
         const std::vector<tbx::Handle>& shader_handles)
     {
@@ -798,7 +823,7 @@ namespace opengl_rendering
         _shaders_by_program.insert_or_assign(program_key, std::move(shader_ids));
     }
 
-    bool OpenGlResourceManager::try_get_raw(
+    bool OpenGlUploader::try_get_raw(
         const tbx::Uuid& resource_uuid,
         std::shared_ptr<IOpenGlResource>& out_resource) const
     {
@@ -810,7 +835,7 @@ namespace opengl_rendering
         return static_cast<bool>(out_resource);
     }
 
-    void OpenGlResourceManager::pin(const tbx::Uuid& resource_uuid)
+    void OpenGlUploader::pin(const tbx::Uuid& resource_uuid)
     {
         const auto it = _resources.find(resource_uuid);
         if (it == _resources.end())
@@ -819,12 +844,12 @@ namespace opengl_rendering
         _pinned_resources.insert_or_assign(resource_uuid, it->second);
     }
 
-    void OpenGlResourceManager::unpin(const tbx::Uuid& resource_uuid)
+    void OpenGlUploader::unpin(const tbx::Uuid& resource_uuid)
     {
         _pinned_resources.erase(resource_uuid);
     }
 
-    void OpenGlResourceManager::clear()
+    void OpenGlUploader::clear()
     {
         _resources.clear();
         _dynamic_mesh_sources.clear();
@@ -835,7 +860,7 @@ namespace opengl_rendering
         _shaders_by_program.clear();
     }
 
-    void OpenGlResourceManager::clear_unused()
+    void OpenGlUploader::clear_unused()
     {
         std::erase_if(
             _resources,
@@ -901,5 +926,18 @@ namespace opengl_rendering
 
             ++iterator;
         }
+    }
+
+    void OpenGlUploader::remove(const tbx::Uuid& resource_uuid)
+    {
+        if (!resource_uuid.is_valid())
+            return;
+
+        clear_shader_dependencies(resource_uuid);
+        _resources.erase(resource_uuid);
+        _dynamic_mesh_sources.erase(resource_uuid);
+        _material_assets.erase(resource_uuid);
+        _pinned_resources.erase(resource_uuid);
+        _last_access.erase(resource_uuid);
     }
 }

--- a/plugins/opengl_rendering/src/opengl_uploader.h
+++ b/plugins/opengl_rendering/src/opengl_uploader.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "opengl_resource.h"
-#include "opengl_shader.h"
+#include "opengl_resources/opengl_resource.h"
+#include "opengl_resources/opengl_shader.h"
 #include "tbx/assets/manager.h"
 #include "tbx/common/uuid.h"
 #include "tbx/graphics/material.h"
@@ -12,12 +12,13 @@
 
 namespace opengl_rendering
 {
-    class OpenGlResourceManager final
+    class OpenGlUploader final
     {
       public:
-        OpenGlResourceManager(tbx::AssetManager& asset_manager);
+        OpenGlUploader(tbx::AssetManager& asset_manager);
 
         tbx::Uuid add_dynamic_mesh(const tbx::DynamicMesh& dynamic_mesh, bool pin = false);
+        tbx::Uuid add_mesh(const tbx::Mesh& mesh, const tbx::Uuid& resource_uuid, bool pin = false);
         tbx::Uuid add_material(const tbx::MaterialInstance& material, bool pin = false);
         tbx::Uuid add_material(
             const std::shared_ptr<OpenGlShaderProgram>& shader_program,
@@ -31,6 +32,7 @@ namespace opengl_rendering
             bool pin = false);
         void clear();
         void clear_unused();
+        void remove(const tbx::Uuid& resource_uuid);
         std::shared_ptr<tbx::Material> get_material_asset(const tbx::Handle& material_handle);
         void on_asset_reloaded(const tbx::Handle& asset_handle);
         void pin(const tbx::Uuid& resource_uuid);
@@ -63,4 +65,4 @@ namespace opengl_rendering
     };
 }
 
-#include "opengl_resource_manager.inl"
+#include "opengl_uploader.inl"

--- a/plugins/opengl_rendering/src/opengl_uploader.inl
+++ b/plugins/opengl_rendering/src/opengl_uploader.inl
@@ -3,13 +3,13 @@
 namespace opengl_rendering
 {
     template <typename TResource>
-    bool OpenGlResourceManager::try_get(
+    bool OpenGlUploader::try_get(
         const tbx::Uuid& resource_uuid,
         std::shared_ptr<TResource>& out_resource) const
     {
         static_assert(
             std::is_base_of_v<IOpenGlResource, TResource>,
-            "OpenGlResourceManager::try_get<TResource> requires TResource to derive "
+            "OpenGlUploader::try_get<TResource> requires TResource to derive "
             "from IOpenGlResource.");
 
         auto out_untyped_resource = std::shared_ptr<IOpenGlResource> {};

--- a/plugins/opengl_rendering/src/passes/GeometryPass.cpp
+++ b/plugins/opengl_rendering/src/passes/GeometryPass.cpp
@@ -2,7 +2,7 @@
 #include "RenderPipelineFailure.h"
 #include "opengl_fallbacks.h"
 #include "opengl_resources/opengl_mesh.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_shader.h"
 #include "tbx/debugging/macros.h"
 #include <glad/glad.h>
@@ -80,7 +80,7 @@ namespace opengl_rendering
         last_bound_count = current_count;
     }
 
-    GeometryPass::GeometryPass(const OpenGlResourceManager& resource_manager)
+    GeometryPass::GeometryPass(const OpenGlUploader& resource_manager)
         : _resource_manager(resource_manager)
     {
     }

--- a/plugins/opengl_rendering/src/passes/GeometryPass.h
+++ b/plugins/opengl_rendering/src/passes/GeometryPass.h
@@ -1,13 +1,13 @@
 #pragma once
 #include "OpenGlDrawCalls.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 
 namespace opengl_rendering
 {
     class GeometryPass final
     {
       public:
-        GeometryPass(const OpenGlResourceManager& resource_manager);
+        GeometryPass(const OpenGlUploader& resource_manager);
         GeometryPass(const GeometryPass&) = delete;
         GeometryPass& operator=(const GeometryPass&) = delete;
         ~GeometryPass() noexcept;
@@ -19,6 +19,6 @@ namespace opengl_rendering
             const std::vector<DrawCall>& draw_calls);
 
       private:
-        const OpenGlResourceManager& _resource_manager;
+        const OpenGlUploader& _resource_manager;
     };
 }

--- a/plugins/opengl_rendering/src/passes/LightingPass.cpp
+++ b/plugins/opengl_rendering/src/passes/LightingPass.cpp
@@ -317,7 +317,7 @@ namespace opengl_rendering
     }
 
     LightingPass::LightingPass(
-        OpenGlResourceManager& resource_manager,
+        OpenGlUploader& resource_manager,
         tbx::JobSystem& job_system,
         OpenGlGBuffer& gbuffer,
         const ShadowPass& shadow_pass)

--- a/plugins/opengl_rendering/src/passes/LightingPass.h
+++ b/plugins/opengl_rendering/src/passes/LightingPass.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "ShadowPass.h"
 #include "opengl_resources/opengl_buffers.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_shader.h"
 #include "tbx/async/job_system.h"
 #include <cstddef>
@@ -19,7 +19,7 @@ namespace opengl_rendering
     {
       public:
         LightingPass(
-            OpenGlResourceManager& resource_manager,
+            OpenGlUploader& resource_manager,
             tbx::JobSystem& job_system,
             OpenGlGBuffer& gbuffer,
             const ShadowPass& shadow_pass);
@@ -47,7 +47,7 @@ namespace opengl_rendering
             const tbx::LightingRenderInfo& lighting);
 
       private:
-        OpenGlResourceManager& _resource_manager;
+        OpenGlUploader& _resource_manager;
         tbx::JobSystem& _job_system;
         OpenGlGBuffer& _gbuffer;
         const ShadowPass& _shadow_pass;

--- a/plugins/opengl_rendering/src/passes/PostProcessingPass.cpp
+++ b/plugins/opengl_rendering/src/passes/PostProcessingPass.cpp
@@ -2,7 +2,7 @@
 #include "RenderPipelineFailure.h"
 #include "opengl_fallbacks.h"
 #include "opengl_resources/opengl_mesh.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_texture.h"
 #include "tbx/debugging/macros.h"
 #include "tbx/graphics/mesh.h"
@@ -89,7 +89,7 @@ namespace opengl_rendering
         OpenGlMaterialParams& material_params,
         const std::string& binding_name,
         const tbx::TextureInstance& texture_instance,
-        OpenGlResourceManager& resource_manager)
+        OpenGlUploader& resource_manager)
     {
         auto texture_id = tbx::Uuid {};
         if (texture_instance.handle.is_valid())
@@ -146,7 +146,7 @@ namespace opengl_rendering
     }
 
     PostProcessingPass::PostProcessingPass(
-        OpenGlResourceManager& resource_manager,
+        OpenGlUploader& resource_manager,
         OpenGlGBuffer& gbuffer)
         : _resource_manager(resource_manager)
         , _gbuffer(gbuffer)

--- a/plugins/opengl_rendering/src/passes/PostProcessingPass.h
+++ b/plugins/opengl_rendering/src/passes/PostProcessingPass.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "opengl_resources/opengl_buffers.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_shader.h"
 #include "tbx/graphics/render_pipeline.h"
 #include "tbx/math/size.h"
@@ -20,7 +20,7 @@ namespace opengl_rendering
     {
       public:
         PostProcessingPass(
-            OpenGlResourceManager& resource_manager,
+            OpenGlUploader& resource_manager,
             OpenGlGBuffer& gbuffer);
         PostProcessingPass(const PostProcessingPass&) = delete;
         PostProcessingPass& operator=(const PostProcessingPass&) = delete;
@@ -40,7 +40,7 @@ namespace opengl_rendering
         bool ensure_scratch_targets(const tbx::Size& size);
 
       private:
-        OpenGlResourceManager& _resource_manager;
+        OpenGlUploader& _resource_manager;
         OpenGlGBuffer& _gbuffer;
         tbx::Size _scratch_size = {0U, 0U};
         std::vector<GLuint> _scratch_textures = {};

--- a/plugins/opengl_rendering/src/passes/ShadowPass.cpp
+++ b/plugins/opengl_rendering/src/passes/ShadowPass.cpp
@@ -440,7 +440,7 @@ void main()
 
     static void render_shadow_batches(
         const std::vector<ShadowDrawCall>& draw_calls,
-        const OpenGlResourceManager& resource_manager,
+        const OpenGlUploader& resource_manager,
         const std::shared_ptr<OpenGlShaderProgram>& shader_program,
         const tbx::Mat4& light_view_projection,
         const tbx::Frustum* shadow_frustum,
@@ -516,7 +516,7 @@ void main()
         glEnable(GL_CULL_FACE);
     }
 
-    ShadowPass::ShadowPass(OpenGlResourceManager& resource_manager)
+    ShadowPass::ShadowPass(OpenGlUploader& resource_manager)
         : _resource_manager(resource_manager)
     {
     }

--- a/plugins/opengl_rendering/src/passes/ShadowPass.h
+++ b/plugins/opengl_rendering/src/passes/ShadowPass.h
@@ -1,6 +1,6 @@
 #pragma once
 #include "OpenGlDrawCalls.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_shader.h"
 #include <memory>
 
@@ -15,7 +15,7 @@ namespace opengl_rendering
     class ShadowPass final
     {
       public:
-        ShadowPass(OpenGlResourceManager& resource_manager);
+        ShadowPass(OpenGlUploader& resource_manager);
         ShadowPass(const ShadowPass&) = delete;
         ShadowPass& operator=(const ShadowPass&) = delete;
         ~ShadowPass() noexcept;
@@ -62,7 +62,7 @@ namespace opengl_rendering
         bool ensure_initialized();
 
       private:
-        OpenGlResourceManager& _resource_manager;
+        OpenGlUploader& _resource_manager;
         std::shared_ptr<OpenGlShaderProgram> _shader_program = nullptr;
         uint32 _framebuffer = 0U;
         uint32 _directional_shadow_texture = 0U;

--- a/plugins/opengl_rendering/src/passes/TransparentPass.cpp
+++ b/plugins/opengl_rendering/src/passes/TransparentPass.cpp
@@ -2,7 +2,7 @@
 #include "RenderPipelineFailure.h"
 #include "opengl_fallbacks.h"
 #include "opengl_resources/opengl_mesh.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 #include "opengl_resources/opengl_shader.h"
 #include "tbx/debugging/macros.h"
 #include <glad/glad.h>
@@ -81,7 +81,7 @@ namespace opengl_rendering
     }
 
     TransparentPass::TransparentPass(
-        const OpenGlResourceManager& resource_manager,
+        const OpenGlUploader& resource_manager,
         OpenGlGBuffer& gbuffer)
         : _resource_manager(resource_manager)
         , _gbuffer(gbuffer)

--- a/plugins/opengl_rendering/src/passes/TransparentPass.h
+++ b/plugins/opengl_rendering/src/passes/TransparentPass.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "OpenGlDrawCalls.h"
 #include "opengl_resources/opengl_buffers.h"
-#include "opengl_resources/opengl_resource_manager.h"
+#include "opengl_uploader.h"
 
 namespace opengl_rendering
 {
@@ -14,7 +14,7 @@ namespace opengl_rendering
     {
       public:
         TransparentPass(
-            const OpenGlResourceManager& resource_manager,
+            const OpenGlUploader& resource_manager,
             OpenGlGBuffer& gbuffer);
         TransparentPass(const TransparentPass&) = delete;
         TransparentPass& operator=(const TransparentPass&) = delete;
@@ -31,7 +31,7 @@ namespace opengl_rendering
             const std::vector<TransparentDrawCall>& draw_calls);
 
       private:
-        const OpenGlResourceManager& _resource_manager;
+        const OpenGlUploader& _resource_manager;
         OpenGlGBuffer& _gbuffer;
     };
 }


### PR DESCRIPTION
### Motivation
- Centralize and manage GPU/backend resource lifetimes for meshes, materials, and textures to decouple engine assets from backend resources.
- Replace direct in-memory mesh/material usage in the render pipeline with backend-stored resource references to avoid redundant uploads and enable explicit upload/unload semantics.

### Description
- Added a `RenderResourceManager` (`render_resources.h/.cpp`) and wired it into the render pipeline as `_resource_manager`, and added the new source to `CMakeLists.txt`.
- Changed render payloads to reference backend resources by `Uuid` (updated `RenderDrawItem`, `RenderShadowItem`, and `RenderSky`) and updated scene building to upload meshes, materials and textures via `RenderResourceManager` during `collect_render_items` and pin/clear lifecycle handling after drawing.
- Evolved the backend API in `IGraphicsBackend` to explicit `upload`/`unload` calls for `Mesh`, `Material`, `Texture`, and `TextureSettings` replacing `on_asset_reloaded`, and updated `RenderingPipeline` usage accordingly (pre-build shadow info, call `clear_unused`).
- Refactored the OpenGL plugin: renamed and reworked `OpenGlResourceManager` -> `OpenGlUploader` and adapted it to the new responsibilities, implemented `OpenGlRenderer::upload`/`unload` methods, replaced per-window renderer states with a single state instance, and updated all passes and headers to use the new uploader/UUID-based flow.

### Testing
- Performed a full project build with `CMake` and compiled the graphics plugin and OpenGL uploader, and the build completed successfully.
- Exercised the rendering pipeline with the updated backend uploader interfaces in a smoke/render integration check and observed no runtime upload/unload failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e65e9564708327ae044eaf9f43935b)