### PR TITLE
Refactor application init to separate filesystem, window, and rendering composition; simplify OpenGL plugin

### DIFF
--- a/modules/app/include/tbx/app/application.h
+++ b/modules/app/include/tbx/app/application.h
@@ -43,7 +43,9 @@ namespace tbx
         const ServiceProvider& get_service_provider() const;
 
       private:
-        void add_default_asset_directory();
+        void setup_filesystem_directories();
+        void setup_main_window();
+        void compose_rendering_service();
         void initialize(const std::vector<std::string>& requested_plugins);
         void update(DeltaTimer& timer);
         void fixed_update(const DeltaTime& dt);

--- a/modules/app/src/application.cpp
+++ b/modules/app/src/application.cpp
@@ -77,8 +77,6 @@ namespace tbx
         else
             settings.paths.logs_directory = file_operator.resolve(desc.logs_directory);
 
-        add_default_asset_directory();
-
         for (auto& arg : desc.args)
         {
             // TODO:
@@ -101,14 +99,11 @@ namespace tbx
         try
         {
             auto& msg_coordinator = _service_provider.get_service<IMessageCoordinator>();
-            auto& window_manager = _service_provider.get_service<IWindowManager>();
             GlobalDispatcherScope scope(msg_coordinator);
 
             auto timer = DeltaTimer();
-            TBX_ASSERT(
-                _main_window.is_valid(),
-                "Application main window must be valid before run.");
-            if (!window_manager.open(_main_window))
+            auto* window_manager = _service_provider.try_get_service<IWindowManager>();
+            if (window_manager && _main_window.is_valid() && !window_manager->open(_main_window))
             {
                 TBX_TRACE_ERROR("Failed to open application main window.");
                 return -1;
@@ -148,13 +143,105 @@ namespace tbx
         return _service_provider;
     }
 
-    void Application::add_default_asset_directory()
+    void Application::setup_filesystem_directories()
     {
+        auto& settings = _service_provider.get_service<AppSettings>();
+        auto& asset_manager = _service_provider.get_service<AssetManager>();
         const auto resource_directory = get_default_asset_directory();
-        if (resource_directory.empty())
-            return;
+        if (!resource_directory.empty())
+            asset_manager.add_directory(resource_directory);
 
-        _service_provider.get_service<AssetManager>().add_directory(resource_directory);
+        TBX_TRACE_INFO("Working Directory: '{}'", settings.paths.working_directory.string());
+        TBX_TRACE_INFO("Logs Directory: '{}'", settings.paths.logs_directory.string());
+        auto asset_roots = asset_manager.get_directories();
+        if (asset_roots.size() > 1)
+        {
+            TBX_TRACE_INFO("Asset Directories:");
+            for (const auto& root : asset_roots)
+                TBX_TRACE_INFO("    -'{}'", root.string());
+        }
+        else if (!asset_roots.empty())
+            TBX_TRACE_INFO("Asset Directory: {}", asset_roots.front().string());
+        else
+            TBX_TRACE_INFO("Asset Directory: <none>");
+    }
+
+    void Application::setup_main_window()
+    {
+        auto* window_manager = _service_provider.try_get_service<IWindowManager>();
+        if (!window_manager)
+        {
+            TBX_TRACE_INFO("Window manager not found. Running without a main window.");
+            return;
+        }
+
+        _main_window_base_title = _name.empty() ? std::string("Toybox Application") : _name;
+        _main_window = window_manager->create(
+            WindowCreateInfo {
+                .title = _main_window_base_title,
+                .size = {1280, 720},
+                .mode = WindowMode::WINDOWED,
+                .open_on_creation = false,
+            });
+    }
+
+    void Application::compose_rendering_service()
+    {
+        auto& settings = _service_provider.get_service<AppSettings>().graphics;
+        if (settings.graphics_api.value == GraphicsApi::NONE)
+        {
+            TBX_TRACE_INFO("Rendering disabled because graphics API is set to None.");
+            return;
+        }
+
+        auto* backend = _service_provider.try_get_service<IGraphicsBackend>();
+        if (!backend)
+        {
+            TBX_TRACE_WARNING(
+                "Rendering service composition skipped because no graphics backend is registered.");
+            return;
+        }
+
+        if (backend->get_api() != settings.graphics_api.value)
+        {
+            TBX_TRACE_WARNING(
+                "Rendering service composition skipped because selected graphics API '{}' does "
+                "not match available backend '{}'.",
+                to_string(settings.graphics_api.value),
+                to_string(backend->get_api()));
+            return;
+        }
+
+        auto* context_manager = _service_provider.try_get_service<IGraphicsContextManager>();
+        if (!context_manager)
+        {
+            TBX_TRACE_WARNING(
+                "Rendering service composition skipped because no graphics context manager is "
+                "registered.");
+            return;
+        }
+
+        if (_service_provider.has_service<IRendering>())
+            _service_provider.deregister_service<IRendering>();
+
+        auto* window_manager = _service_provider.try_get_service<IWindowManager>();
+        if (!window_manager)
+        {
+            TBX_TRACE_WARNING(
+                "Rendering service composition skipped because no window manager is registered.");
+            return;
+        }
+
+        _service_provider.register_service<IRendering>(std::make_unique<Rendering>(
+            _service_provider.get_service<IMessageCoordinator>(),
+            _service_provider.get_service<ThreadManager>(),
+            _service_provider.get_service<EntityRegistry>(),
+            _service_provider.get_service<AssetManager>(),
+            _service_provider.get_service<JobSystem>(),
+            settings,
+            *window_manager,
+            *context_manager,
+            *backend));
     }
 
     void Application::initialize(const std::vector<std::string>& requested_plugins)
@@ -162,8 +249,6 @@ namespace tbx
         const auto startup_begin = std::chrono::steady_clock::now();
         auto& msg_coordinator = _service_provider.get_service<IMessageCoordinator>();
         auto& settings = _service_provider.get_service<AppSettings>();
-        auto& asset_manager = _service_provider.get_service<AssetManager>();
-
         try
         {
             GlobalDispatcherScope scope(msg_coordinator);
@@ -182,40 +267,16 @@ namespace tbx
                     recieve_message(msg);
                 });
 
+            setup_filesystem_directories();
+
             // Load requested plugins
             _plugin_manager.load(
                 settings.paths.working_directory,
                 requested_plugins,
                 settings.paths.working_directory);
 
-            auto* window_manager = _service_provider.try_get_service<IWindowManager>();
-            TBX_ASSERT(window_manager, "Application requires an IWindowManager service.");
-            if (!window_manager)
-                throw std::runtime_error("Application requires an IWindowManager service.");
-
-            _main_window_base_title = _name.empty() ? std::string("Toybox Application") : _name;
-            _main_window = window_manager->create(
-                WindowCreateInfo {
-                    .title = _main_window_base_title,
-                    .size = {1280, 720},
-                    .mode = WindowMode::WINDOWED,
-                    .open_on_creation = false,
-                });
-
-            // Log filesystem directories
-            TBX_TRACE_INFO("Working Directory: '{}'", settings.paths.working_directory.string());
-            TBX_TRACE_INFO("Logs Directory: '{}'", settings.paths.logs_directory.string());
-            auto asset_roots = asset_manager.get_directories();
-            if (asset_roots.size() > 1)
-            {
-                TBX_TRACE_INFO("Asset Directories:");
-                for (const auto& root : asset_roots)
-                    TBX_TRACE_INFO("    -'{}'", root.string());
-            }
-            else if (!asset_roots.empty())
-                TBX_TRACE_INFO("Asset Directory: {}", asset_roots.front().string());
-            else
-                TBX_TRACE_INFO("Asset Directory: <none>");
+            setup_main_window();
+            compose_rendering_service();
 
             // Tell everyone we're initialized
             msg_coordinator.send<ApplicationInitializedEvent>(this);

--- a/plugins/opengl_rendering/include/tbx/plugins/opengl_rendering/opengl_rendering_plugin.h
+++ b/plugins/opengl_rendering/include/tbx/plugins/opengl_rendering/opengl_rendering_plugin.h
@@ -5,7 +5,7 @@
 namespace opengl_rendering
 {
     /// @brief
-    /// Purpose: Registers the OpenGL graphics backend and engine-owned rendering service.
+    /// Purpose: Registers the OpenGL graphics backend service.
     /// @details
     /// Ownership: Services are registered into the host service provider during plugin attach.
     /// Thread Safety: Expected to be attached and detached on the host thread.

--- a/plugins/opengl_rendering/src/opengl_rendering_plugin.cpp
+++ b/plugins/opengl_rendering/src/opengl_rendering_plugin.cpp
@@ -1,11 +1,7 @@
 #include "tbx/plugins/opengl_rendering/opengl_rendering_plugin.h"
 #include "opengl_renderer.h"
-#include "tbx/app/settings.h"
 #include "tbx/assets/manager.h"
 #include "tbx/async/job_system.h"
-#include "tbx/async/thread_manager.h"
-#include "tbx/ecs/entity_registry.h"
-#include "tbx/messages/dispatcher.h"
 
 namespace opengl_rendering
 {
@@ -15,33 +11,14 @@ namespace opengl_rendering
     {
         _service_provider = &service_provider;
 
-        auto& message_coordinator = service_provider.get_service<tbx::IMessageCoordinator>();
-        auto& thread_manager = service_provider.get_service<tbx::ThreadManager>();
-        auto& entity_registry = service_provider.get_service<tbx::EntityRegistry>();
         auto& asset_manager = service_provider.get_service<tbx::AssetManager>();
         auto& job_system = service_provider.get_service<tbx::JobSystem>();
-        auto& settings = service_provider.get_service<tbx::AppSettings>().graphics;
-        auto& window_manager = service_provider.get_service<tbx::IWindowManager>();
         service_provider.register_service<tbx::IGraphicsBackend>(
             std::make_unique<OpenGlRenderer>(asset_manager, job_system));
-
-        auto& backend = service_provider.get_service<tbx::IGraphicsBackend>();
-        service_provider.register_service<tbx::IRendering>(std::make_unique<tbx::Rendering>(
-            message_coordinator,
-            thread_manager,
-            entity_registry,
-            asset_manager,
-            job_system,
-            settings,
-            window_manager,
-            service_provider.get_service<tbx::IGraphicsContextManager>(),
-            backend));
     }
 
     void OpenGlRenderingPlugin::on_detach()
     {
-        if (_service_provider && _service_provider->has_service<tbx::IRendering>())
-            _service_provider->deregister_service<tbx::IRendering>();
         if (_service_provider && _service_provider->has_service<tbx::IGraphicsBackend>())
             _service_provider->deregister_service<tbx::IGraphicsBackend>();
 


### PR DESCRIPTION
### Motivation
- Separate application startup responsibilities to make filesystem logging, window creation, and rendering composition independent and more robust.
- Avoid a hard dependency on `IWindowManager` during `run()` so the app can operate headless or without a window manager.
- Defer rendering service composition until after plugins/backends are registered and ensure the selected graphics backend/context match the configured graphics API.

### Description
- Introduced `setup_filesystem_directories()`, `setup_main_window()`, and `compose_rendering_service()` and relocated filesystem logging and asset-directory handling into `setup_filesystem_directories()`.
- Moved main window creation into `setup_main_window()` and changed `run()` to optionally open the main window only when an `IWindowManager` is present, removing the previous assert for a valid main window.
- Added `compose_rendering_service()` to conditionally register `IRendering` based on `AppSettings.graphics`, available `IGraphicsBackend`, `IGraphicsContextManager`, and `IWindowManager`, and to deregister any existing `IRendering` before registering a new one.
- Simplified the OpenGL plugin to only register the `IGraphicsBackend` (`OpenGlRenderer`) and removed its direct creation/deregistration of the engine-owned `IRendering` service and related heavy includes.

### Testing
- Built the project successfully using the project build system (`cmake --build .`) which completed without errors.
- Ran the automated unit and integration test suite (`ctest --output-on-failure`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a98426a08327a8182223b6f67ac1)