### PR TITLE
Add Rendering system and GraphicsRenderPipeline; integrate rendering into Application

### DIFF
--- a/modules/app/include/tbx/app/application.h
+++ b/modules/app/include/tbx/app/application.h
@@ -8,6 +8,7 @@
 #include "tbx/assets/builtin_assets.h"
 #include "tbx/ecs/entity.h"
 #include "tbx/ecs/entity_registry.h"
+#include "tbx/graphics/rendering.h"
 #include "tbx/graphics/window.h"
 #include "tbx/input/manager.h"
 #include "tbx/plugin_api/plugin_manager.h"
@@ -59,6 +60,7 @@ namespace tbx
         ServiceProvider _service_provider = {};
         PluginManager _plugin_manager;
         Window _main_window = {};
+        Rendering _rendering = {};
         std::string _main_window_base_title = {};
 
         uint _update_count = 0;

--- a/modules/app/src/application.cpp
+++ b/modules/app/src/application.cpp
@@ -3,6 +3,7 @@
 #include "tbx/app/requests.h"
 #include "tbx/debugging/macros.h"
 #include "tbx/files/ops.h"
+#include "tbx/graphics/graphics_backend.h"
 #include "tbx/graphics/messages.h"
 #include "tbx/messages/dispatcher.h"
 #include "tbx/time/delta_time.h"
@@ -201,6 +202,18 @@ namespace tbx
                     .open_on_creation = false,
                 });
 
+            if (auto* graphics_backend = _service_provider.try_get_service<IGraphicsBackend>())
+            {
+                const auto initialize_result =
+                    _rendering.initialize(*graphics_backend, settings.graphics);
+                if (!initialize_result)
+                {
+                    TBX_TRACE_WARNING(
+                        "Toybox renderer initialization failed: {}",
+                        initialize_result.get_report());
+                }
+            }
+
             // Log filesystem directories
             TBX_TRACE_INFO("Working Directory: '{}'", settings.paths.working_directory.string());
             TBX_TRACE_INFO("Logs Directory: '{}'", settings.paths.logs_directory.string());
@@ -251,6 +264,7 @@ namespace tbx
     {
         auto& msg_coordinator = _service_provider.get_service<IMessageCoordinator>();
         auto& asset_manager = _service_provider.get_service<AssetManager>();
+        auto& settings = _service_provider.get_service<AppSettings>();
 
         // Process messages posted in previous frame
         msg_coordinator.flush();
@@ -268,6 +282,34 @@ namespace tbx
 
         // Update all loaded plugins
         _plugin_manager.update(dt);
+
+        if (auto* graphics_backend = _service_provider.try_get_service<IGraphicsBackend>())
+        {
+            if (_main_window.is_valid())
+            {
+                if (auto* window_manager = _service_provider.try_get_service<IWindowManager>())
+                {
+                    const auto render_resolution = settings.graphics.resolution.value.width > 0U
+                                                       && settings.graphics.resolution.value.height
+                                                              > 0U
+                                                   ? settings.graphics.resolution.value
+                                                   : window_manager->get_size(_main_window);
+                    const auto render_result = _rendering.submit(
+                        *graphics_backend,
+                        RenderViewSubmission {
+                            .output_window = _main_window,
+                            .camera = Camera {},
+                            .resolution = render_resolution,
+                        });
+                    if (!render_result)
+                    {
+                        TBX_TRACE_WARNING(
+                            "Toybox renderer frame submission failed: {}",
+                            render_result.get_report());
+                    }
+                }
+            }
+        }
 
         if (auto* input_manager = _service_provider.try_get_service<IInputManager>())
             input_manager->update(dt);

--- a/modules/graphics/include/tbx/graphics/render_pipeline.h
+++ b/modules/graphics/include/tbx/graphics/render_pipeline.h
@@ -1,0 +1,81 @@
+#pragma once
+#include "tbx/common/pipeline.h"
+#include "tbx/common/result.h"
+#include "tbx/common/uuid.h"
+#include "tbx/graphics/graphics_backend.h"
+#include "tbx/graphics/viewport.h"
+#include "tbx/tbx_api.h"
+#include <any>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace tbx
+{
+    struct TBX_API GraphicsDrawCommand
+    {
+        Uuid pipeline = {};
+        std::vector<GraphicsResourceBinding> vertex_buffers = {};
+        std::vector<GraphicsResourceBinding> uniform_buffers = {};
+        std::vector<GraphicsResourceBinding> storage_buffers = {};
+        std::vector<GraphicsResourceBinding> textures = {};
+        std::vector<GraphicsResourceBinding> samplers = {};
+        uint32 vertex_count = 0U;
+        uint32 vertex_offset = 0U;
+    };
+
+    struct TBX_API GraphicsIndexedDrawCommand
+    {
+        Uuid pipeline = {};
+        std::vector<GraphicsResourceBinding> vertex_buffers = {};
+        Uuid index_buffer = {};
+        GraphicsIndexType index_type = GraphicsIndexType::UINT32;
+        std::vector<GraphicsResourceBinding> uniform_buffers = {};
+        std::vector<GraphicsResourceBinding> storage_buffers = {};
+        std::vector<GraphicsResourceBinding> textures = {};
+        std::vector<GraphicsResourceBinding> samplers = {};
+        GraphicsDrawIndexedDesc draw = {};
+    };
+
+    struct TBX_API GraphicsRenderPass
+    {
+        GraphicsPassDesc pass = {};
+        std::optional<Viewport> viewport = std::nullopt;
+        std::vector<GraphicsDrawCommand> draws = {};
+        std::vector<GraphicsIndexedDrawCommand> indexed_draws = {};
+    };
+
+    struct TBX_API GraphicsPipelineExecutionContext
+    {
+        IGraphicsBackend* backend = nullptr;
+        Result* result = nullptr;
+    };
+
+    class TBX_API GraphicsRenderPassOperation final : public PipelineOperation
+    {
+      public:
+        GraphicsRenderPassOperation(GraphicsRenderPass pass);
+
+      public:
+        void execute(const std::any& payload) override;
+        const GraphicsRenderPass& get_pass() const;
+
+      private:
+        GraphicsRenderPass _pass = {};
+    };
+
+    class TBX_API GraphicsRenderPipeline
+    {
+      public:
+        void add_operation(std::unique_ptr<PipelineOperation> operation);
+        void add_pass_operation(GraphicsRenderPass pass);
+        void clear();
+
+        Result execute(IGraphicsBackend& backend) const;
+
+        const Pipeline& get_pipeline() const;
+
+      private:
+        mutable Pipeline _pipeline = {};
+    };
+}

--- a/modules/graphics/include/tbx/graphics/renderer.h
+++ b/modules/graphics/include/tbx/graphics/renderer.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "tbx/graphics/lods.h"
+#include "tbx/graphics/material.h"
+#include "tbx/graphics/post_processing.h"

--- a/modules/graphics/include/tbx/graphics/rendering.h
+++ b/modules/graphics/include/tbx/graphics/rendering.h
@@ -2,45 +2,40 @@
 #include "tbx/common/result.h"
 #include "tbx/graphics/camera.h"
 #include "tbx/graphics/graphics_backend.h"
-#include "tbx/graphics/render_graph.h"
 #include "tbx/graphics/render_pipeline.h"
+#include "tbx/graphics/settings.h"
 #include "tbx/graphics/window.h"
 #include "tbx/math/size.h"
 #include "tbx/tbx_api.h"
+#include <vector>
 
 namespace tbx
 {
+    struct TBX_API RenderViewSubmission
+    {
+        Window output_window = {};
+        Camera camera = {};
+        Size resolution = {};
+    };
+
     /// @brief
     /// Purpose: Coordinates Toybox-side render submission against a graphics backend.
     /// @details
-    /// Ownership: Does not own the backend or scene data; backends own realized GPU state.
+    /// Ownership: Owns the Toybox render pipeline; does not own backend resources.
     /// Thread Safety: Not inherently thread-safe; callers should synchronize backend access.
     class TBX_API Rendering
     {
       public:
-        /// @brief
-        /// Purpose: Opens a frame and presents it using the command-based backend contract.
-        /// @details
-        /// Ownership: Reads submission data during the call. Render passes issue explicit backend
-        /// commands separately.
-        /// Thread Safety: Not inherently thread-safe; callers should synchronize backend access.
-        Result submit(
-            IGraphicsBackend& backend,
-            const Window& output_window,
-            const Camera& view,
-            const Size& resolution,
-            const RenderGraph& scene) const;
+        Result initialize(IGraphicsBackend& backend, const GraphicsSettings& settings);
+        void setup_default_pipeline();
 
-        /// @brief
-        /// Purpose: Renders a Toybox-owned command pipeline through a graphics backend.
-        /// @details
-        /// Ownership: Reads pipeline data during the call; backend owns realized GPU resources.
-        /// Thread Safety: Not inherently thread-safe; callers should synchronize backend access.
-        Result submit(
-            IGraphicsBackend& backend,
-            const Window& output_window,
-            const Camera& view,
-            const Size& resolution,
-            const GraphicsRenderPipeline& pipeline) const;
+        Result submit(IGraphicsBackend& backend, const RenderViewSubmission& view) const;
+        Result submit(IGraphicsBackend& backend, const std::vector<RenderViewSubmission>& views) const;
+
+        const GraphicsRenderPipeline& get_pipeline() const;
+
+      private:
+        GraphicsRenderPipeline _pipeline = {};
+        bool _is_initialized = false;
     };
 }

--- a/modules/graphics/src/render_pipeline.cpp
+++ b/modules/graphics/src/render_pipeline.cpp
@@ -1,6 +1,4 @@
 #include "tbx/graphics/render_pipeline.h"
-#include "tbx/debugging/macros.h"
-#include <string>
 #include <utility>
 
 namespace tbx
@@ -92,127 +90,81 @@ namespace tbx
         return backend.draw_indexed(command.draw);
     }
 
-    static bool should_prepare_geometry_pass(const GraphicsSceneRenderPass pass)
+    GraphicsRenderPassOperation::GraphicsRenderPassOperation(GraphicsRenderPass pass)
+        : _pass(std::move(pass))
     {
-        return pass == GraphicsSceneRenderPass::GEOMETRY;
     }
 
-    GraphicsRenderPipeline GraphicsRenderPipeline::create_default_scene_pipeline()
+    void GraphicsRenderPassOperation::execute(const std::any& payload)
     {
-        auto pipeline = GraphicsRenderPipeline {};
-        pipeline.add_scene_pass(GraphicsSceneRenderPass::SHADOWS);
-        pipeline.add_scene_pass(GraphicsSceneRenderPass::GEOMETRY);
-        pipeline.add_scene_pass(GraphicsSceneRenderPass::LIGHTING);
-        pipeline.add_scene_pass(GraphicsSceneRenderPass::TRANSPARENT);
-        pipeline.add_scene_pass(GraphicsSceneRenderPass::POST_PROCESSING);
-        return pipeline;
+        const auto* context = std::any_cast<GraphicsPipelineExecutionContext>(&payload);
+        if (!context || !context->backend || !context->result || !context->result->succeeded())
+            return;
+
+        auto& backend = *context->backend;
+        auto& result = *context->result;
+
+        if (_pass.viewport.has_value())
+        {
+            result = backend.set_viewport(_pass.viewport.value());
+            if (!result)
+                return;
+        }
+
+        result = backend.begin_pass(_pass.pass);
+        if (!result)
+            return;
+
+        for (const auto& draw : _pass.draws)
+        {
+            result = execute_draw(backend, draw);
+            if (!result)
+                return;
+        }
+
+        for (const auto& draw : _pass.indexed_draws)
+        {
+            result = execute_draw(backend, draw);
+            if (!result)
+                return;
+        }
+
+        result = backend.end_pass();
     }
 
-    void GraphicsRenderPipeline::add_pass(GraphicsRenderPass pass)
+    const GraphicsRenderPass& GraphicsRenderPassOperation::get_pass() const
     {
-        _passes.push_back(std::move(pass));
+        return _pass;
     }
 
-    void GraphicsRenderPipeline::add_scene_pass(const GraphicsSceneRenderPass pass)
+    void GraphicsRenderPipeline::add_operation(std::unique_ptr<PipelineOperation> operation)
     {
-        _scene_passes.push_back(pass);
+        _pipeline.add_operation(std::move(operation));
+    }
+
+    void GraphicsRenderPipeline::add_pass_operation(GraphicsRenderPass pass)
+    {
+        add_operation(std::make_unique<GraphicsRenderPassOperation>(std::move(pass)));
     }
 
     void GraphicsRenderPipeline::clear()
     {
-        _passes.clear();
-        _scene_passes.clear();
-        _has_reported_scene_failure = false;
-    }
-
-    const std::vector<GraphicsRenderPass>& GraphicsRenderPipeline::get_passes() const
-    {
-        return _passes;
-    }
-
-    const std::vector<GraphicsSceneRenderPass>& GraphicsRenderPipeline::get_scene_passes() const
-    {
-        return _scene_passes;
+        _pipeline.clear_operations();
     }
 
     Result GraphicsRenderPipeline::execute(IGraphicsBackend& backend) const
     {
-        for (const auto& pass : _passes)
-        {
-            if (pass.viewport.has_value())
-            {
-                if (const auto result = backend.set_viewport(pass.viewport.value()); !result)
-                    return result;
-            }
-
-            if (const auto result = backend.begin_pass(pass.pass); !result)
-                return result;
-
-            for (const auto& draw : pass.draws)
-            {
-                if (const auto result = execute_draw(backend, draw); !result)
-                    return result;
-            }
-
-            for (const auto& draw : pass.indexed_draws)
-            {
-                if (const auto result = execute_draw(backend, draw); !result)
-                    return result;
-            }
-
-            if (const auto result = backend.end_pass(); !result)
-                return result;
-        }
-
-        return {};
+        auto result = Result {};
+        auto context = GraphicsPipelineExecutionContext {
+            .backend = &backend,
+            .result = &result,
+        };
+        _pipeline.execute(context);
+        return result;
     }
 
-    Result GraphicsRenderPipeline::execute(
-        IGraphicsSceneRenderBackend& backend,
-        const std::any& payload)
+    const Pipeline& GraphicsRenderPipeline::get_pipeline() const
     {
-        auto saw_failure = false;
-        auto failure_report = std::string {};
-
-        for (const auto pass : _scene_passes)
-        {
-            if (should_prepare_geometry_pass(pass))
-            {
-                if (const auto result = backend.prepare_geometry_pass(); !result)
-                {
-                    saw_failure = true;
-                    failure_report = result.get_report();
-                    break;
-                }
-            }
-
-            if (const auto result = backend.execute_scene_pass(pass, payload); !result)
-            {
-                saw_failure = true;
-                failure_report = result.get_report();
-            }
-        }
-
-        if (!saw_failure)
-        {
-            _has_reported_scene_failure = false;
-            return {};
-        }
-
-        if (!_has_reported_scene_failure)
-        {
-            TBX_TRACE_WARNING(
-                "Graphics rendering: one or more render passes failed without producing a usable "
-                "frame. Rendering magenta fallback frame. {}",
-                failure_report);
-            _has_reported_scene_failure = true;
-        }
-
-        return render_failure_frame(backend);
-    }
-
-    Result GraphicsRenderPipeline::render_failure_frame(IGraphicsSceneRenderBackend& backend)
-    {
-        return backend.render_failure_frame();
+        return _pipeline;
     }
 }

--- a/modules/graphics/src/rendering.cpp
+++ b/modules/graphics/src/rendering.cpp
@@ -2,29 +2,23 @@
 
 namespace tbx
 {
-    static Result begin_frame_and_view(
-        IGraphicsBackend& backend,
-        const Window& output_window,
-        const Camera& view,
-        const Size& resolution)
+    static Result begin_frame_and_view(IGraphicsBackend& backend, const RenderViewSubmission& view)
     {
-        const auto frame =
-            GraphicsFrameInfo {
-                .output_window = output_window,
-                .render_resolution = resolution,
-                .output_resolution = resolution,
-            };
+        const auto frame = GraphicsFrameInfo {
+            .output_window = view.output_window,
+            .render_resolution = view.resolution,
+            .output_resolution = view.resolution,
+        };
         if (const auto result = backend.begin_frame(frame); !result)
             return result;
 
-        const auto graphics_view =
-            GraphicsView {
-                .camera = view,
-                .viewport = Viewport {
-                    .position = Vec2(0.0F),
-                    .dimensions = resolution,
-                },
-            };
+        const auto graphics_view = GraphicsView {
+            .camera = view.camera,
+            .viewport = Viewport {
+                .position = Vec2(0.0F),
+                .dimensions = view.resolution,
+            },
+        };
         if (const auto result = backend.begin_view(graphics_view); !result)
             return result;
 
@@ -41,32 +35,43 @@ namespace tbx
         return backend.end_frame();
     }
 
-    Result Rendering::submit(
-        IGraphicsBackend& backend,
-        const Window& output_window,
-        const Camera& view,
-        const Size& resolution,
-        const RenderGraph& scene) const
+    Result Rendering::initialize(IGraphicsBackend& backend, const GraphicsSettings& settings)
     {
-        (void)scene;
+        if (_is_initialized)
+            return {};
 
-        if (const auto result = begin_frame_and_view(backend, output_window, view, resolution);
-            !result)
+        if (const auto result = backend.initialize(settings); !result)
             return result;
 
-        const auto pass =
-            GraphicsPassDesc {
-                .color_targets = {},
-                .depth_stencil_target = {},
-                .clear_color = Color::BLACK,
-                .clear_depth = 1.0F,
-                .clear_stencil = 0U,
-                .clear_flags = GraphicsClearFlags::COLOR_DEPTH,
-                .debug_name = "Frame Output",
-            };
-        if (const auto result = backend.begin_pass(pass); !result)
+        setup_default_pipeline();
+        _is_initialized = true;
+        return {};
+    }
+
+    void Rendering::setup_default_pipeline()
+    {
+        _pipeline.clear();
+        _pipeline.add_pass_operation(
+            GraphicsRenderPass {
+                .pass =
+                    GraphicsPassDesc {
+                        .clear_color = Color::BLACK,
+                        .clear_depth = 1.0F,
+                        .clear_stencil = 0U,
+                        .clear_flags = GraphicsClearFlags::COLOR_DEPTH,
+                        .debug_name = "Toybox Geometry Pass",
+                    },
+            });
+    }
+
+    Result Rendering::submit(IGraphicsBackend& backend, const RenderViewSubmission& view) const
+    {
+        if (!_is_initialized)
+            return Result(false, "Rendering::initialize must be called before submit.");
+
+        if (const auto result = begin_frame_and_view(backend, view); !result)
             return result;
-        if (const auto result = backend.end_pass(); !result)
+        if (const auto result = _pipeline.execute(backend); !result)
             return result;
 
         return end_view_and_frame(backend);
@@ -74,17 +79,19 @@ namespace tbx
 
     Result Rendering::submit(
         IGraphicsBackend& backend,
-        const Window& output_window,
-        const Camera& view,
-        const Size& resolution,
-        const GraphicsRenderPipeline& pipeline) const
+        const std::vector<RenderViewSubmission>& views) const
     {
-        if (const auto result = begin_frame_and_view(backend, output_window, view, resolution);
-            !result)
-            return result;
-        if (const auto result = pipeline.execute(backend); !result)
-            return result;
+        for (const auto& view : views)
+        {
+            if (const auto result = submit(backend, view); !result)
+                return result;
+        }
 
-        return end_view_and_frame(backend);
+        return {};
+    }
+
+    const GraphicsRenderPipeline& Rendering::get_pipeline() const
+    {
+        return _pipeline;
     }
 }

--- a/modules/graphics/tests/graphics_backend_tests.cpp
+++ b/modules/graphics/tests/graphics_backend_tests.cpp
@@ -2,6 +2,8 @@
 #include "tbx/graphics/graphics_backend.h"
 #include "tbx/graphics/render_pipeline.h"
 #include "tbx/graphics/rendering.h"
+#include "tbx/messages/dispatcher.h"
+#include <future>
 #include <vector>
 
 namespace tbx::tests::graphics
@@ -27,16 +29,6 @@ namespace tbx::tests::graphics
         EndFrame,
     };
 
-    enum class GraphicsSceneBackendCallback
-    {
-        Shadows,
-        PrepareGeometry,
-        Geometry,
-        Lighting,
-        Transparent,
-        PostProcessing,
-        FailureFrame,
-    };
 
     class RecordingGraphicsBackend final : public IGraphicsBackend
     {
@@ -243,52 +235,20 @@ namespace tbx::tests::graphics
         GraphicsDrawIndexedDesc recorded_draw = {};
     };
 
-    class RecordingSceneRenderBackend final : public IGraphicsSceneRenderBackend
+    class NullMessageDispatcher final : public IMessageDispatcher
     {
-      public:
-        Result execute_scene_pass(const GraphicsSceneRenderPass pass, const std::any&) override
+      protected:
+        Result send(Message&) const override
         {
-            switch (pass)
-            {
-                case GraphicsSceneRenderPass::SHADOWS:
-                    callbacks.push_back(GraphicsSceneBackendCallback::Shadows);
-                    break;
-                case GraphicsSceneRenderPass::GEOMETRY:
-                    callbacks.push_back(GraphicsSceneBackendCallback::Geometry);
-                    break;
-                case GraphicsSceneRenderPass::LIGHTING:
-                    callbacks.push_back(GraphicsSceneBackendCallback::Lighting);
-                    if (should_fail_lighting)
-                        return Result(false, "lighting failed");
-                    break;
-                case GraphicsSceneRenderPass::TRANSPARENT:
-                    callbacks.push_back(GraphicsSceneBackendCallback::Transparent);
-                    break;
-                case GraphicsSceneRenderPass::POST_PROCESSING:
-                    callbacks.push_back(GraphicsSceneBackendCallback::PostProcessing);
-                    break;
-                default:
-                    return Result(false, "unknown pass");
-            }
-
             return {};
         }
 
-        Result prepare_geometry_pass() override
+        std::shared_future<Result> post(std::unique_ptr<Message>) const override
         {
-            callbacks.push_back(GraphicsSceneBackendCallback::PrepareGeometry);
-            return {};
+            auto promise = std::promise<Result> {};
+            promise.set_value(Result {});
+            return promise.get_future().share();
         }
-
-        Result render_failure_frame() override
-        {
-            callbacks.push_back(GraphicsSceneBackendCallback::FailureFrame);
-            return {};
-        }
-
-      public:
-        std::vector<GraphicsSceneBackendCallback> callbacks = {};
-        bool should_fail_lighting = false;
     };
 
     // Validates Rendering opens frame state through the command-based backend API.
@@ -296,14 +256,24 @@ namespace tbx::tests::graphics
     {
         // Arrange
         auto backend = RecordingGraphicsBackend {};
-        const auto rendering = Rendering {};
+        auto rendering = Rendering {};
+        auto dispatcher = NullMessageDispatcher {};
+        auto settings = GraphicsSettings(
+            dispatcher,
+            false,
+            GraphicsApi::OPEN_GL,
+            Size {1280U, 720U});
         const auto output_window = Window("main");
-        const auto camera = Camera {};
         const auto resolution = Size {1280U, 720U};
-        const auto scene = RenderGraph {};
+        const auto view = RenderViewSubmission {
+            .output_window = output_window,
+            .camera = Camera {},
+            .resolution = resolution,
+        };
 
         // Act
-        const auto result = rendering.submit(backend, output_window, camera, resolution, scene);
+        const auto initialize_result = rendering.initialize(backend, settings);
+        const auto result = rendering.submit(backend, view);
 
         // Assert
         const auto expected_callbacks = std::vector<GraphicsBackendCallback> {
@@ -317,6 +287,7 @@ namespace tbx::tests::graphics
             GraphicsBackendCallback::EndFrame,
         };
 
+        EXPECT_TRUE(initialize_result);
         EXPECT_TRUE(result);
         EXPECT_EQ(backend.recorded_output_window.get_id(), output_window.get_id());
         EXPECT_EQ(backend.recorded_render_resolution.width, resolution.width);
@@ -324,6 +295,7 @@ namespace tbx::tests::graphics
         EXPECT_EQ(backend.recorded_viewport.width, resolution.width);
         EXPECT_EQ(backend.recorded_viewport.height, resolution.height);
         EXPECT_EQ(backend.recorded_pass.clear_flags, GraphicsClearFlags::COLOR_DEPTH);
+        EXPECT_EQ(backend.recorded_pass.debug_name, "Toybox Geometry Pass");
         EXPECT_EQ(backend.callbacks, expected_callbacks);
     }
 
@@ -393,7 +365,7 @@ namespace tbx::tests::graphics
         // Arrange
         auto backend = RecordingGraphicsBackend {};
         auto pipeline = GraphicsRenderPipeline {};
-        pipeline.add_pass(
+        pipeline.add_pass_operation(
             GraphicsRenderPass {
                 .pass =
                     GraphicsPassDesc {
@@ -456,29 +428,52 @@ namespace tbx::tests::graphics
         EXPECT_EQ(backend.callbacks, expected_callbacks);
     }
 
-    // Validates the graphics module owns scene pass order and fallback behavior.
-    TEST(GraphicsRenderPipelineTests, ExecuteScenePipeline_RendersFailureFrameAfterPassFailure)
+    // Validates Rendering owns the Toybox geometry pipeline and submits pass commands.
+    TEST(GraphicsRenderPipelineTests, Rendering_InitializesAndSubmitsGeometryPass)
     {
         // Arrange
-        auto backend = RecordingSceneRenderBackend {};
-        backend.should_fail_lighting = true;
-        auto pipeline = GraphicsRenderPipeline::create_default_scene_pipeline();
+        auto backend = RecordingGraphicsBackend {};
+        auto rendering = Rendering {};
+        auto dispatcher = NullMessageDispatcher {};
+        auto settings = GraphicsSettings(
+            dispatcher,
+            false,
+            GraphicsApi::OPEN_GL,
+            Size {1280U, 720U});
 
         // Act
-        const auto result = pipeline.execute(backend, {});
+        const auto initialize_result = rendering.initialize(backend, settings);
+        const auto render_result = rendering.submit(
+            backend,
+            RenderViewSubmission {
+                .output_window = Window("main"),
+                .camera = Camera {},
+                .resolution = Size {1280U, 720U},
+            });
 
         // Assert
-        const auto expected_callbacks = std::vector<GraphicsSceneBackendCallback> {
-            GraphicsSceneBackendCallback::Shadows,
-            GraphicsSceneBackendCallback::PrepareGeometry,
-            GraphicsSceneBackendCallback::Geometry,
-            GraphicsSceneBackendCallback::Lighting,
-            GraphicsSceneBackendCallback::Transparent,
-            GraphicsSceneBackendCallback::PostProcessing,
-            GraphicsSceneBackendCallback::FailureFrame,
+        const auto expected_callbacks = std::vector<GraphicsBackendCallback> {
+            GraphicsBackendCallback::BeginFrame,
+            GraphicsBackendCallback::BeginView,
+            GraphicsBackendCallback::SetViewport,
+            GraphicsBackendCallback::BeginPass,
+            GraphicsBackendCallback::EndPass,
+            GraphicsBackendCallback::EndView,
+            GraphicsBackendCallback::Present,
+            GraphicsBackendCallback::EndFrame,
         };
 
-        EXPECT_TRUE(result);
+        const auto& operations = rendering.get_pipeline().get_pipeline().get_operations();
+        ASSERT_EQ(operations.size(), 1U);
+        const auto* geometry_operation =
+            dynamic_cast<const GraphicsRenderPassOperation*>(operations.front().get());
+        ASSERT_NE(geometry_operation, nullptr);
+        EXPECT_EQ(geometry_operation->get_pass().pass.debug_name, "Toybox Geometry Pass");
+        EXPECT_EQ(
+            geometry_operation->get_pass().pass.clear_flags,
+            GraphicsClearFlags::COLOR_DEPTH);
+        EXPECT_TRUE(initialize_result);
+        EXPECT_TRUE(render_result);
         EXPECT_EQ(backend.callbacks, expected_callbacks);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a Toybox-owned rendering layer and pipeline so the application can submit frames to a command-based graphics backend and own default pass configuration.
- Replace the old scene-pass contract with a flexible command pipeline and explicit view submissions so backends implement a minimal `IGraphicsBackend` contract.

### Description
- Add a `Rendering` API and `GraphicsRenderPipeline` including `GraphicsRenderPassOperation` and supporting types in `tbx/graphics` to own and execute Toybox render passes (`rendering.h`, `render_pipeline.h`, `render_pipeline.cpp`, `rendering.cpp`, `renderer.h`).
- Introduce `RenderViewSubmission` and `Rendering::initialize`/`submit` overloads along with a default geometry pass via `Rendering::setup_default_pipeline` and internal `_is_initialized` tracking.
- Integrate rendering into the application by adding a `_rendering` member to `Application`, initializing it during `Application::initialize` with the `IGraphicsBackend` and `AppSettings`, and submitting frames from `Application::update` when a graphics backend and valid main window exist.
- Update graphics unit tests to exercise the new APIs and pipeline ownership, including use of `RecordingGraphicsBackend` and a `NullMessageDispatcher` in tests (`graphics_backend_tests.cpp`).

### Testing
- Ran `RenderingTests.Submit_DelegatesFrameAndOutputPassCommands` which validates frame/view life-cycle calls, and it passed.
- Ran `GraphicsBackendTests.ExplicitCommands_CanDescribeIndexedGeometryDraw` which validates explicit backend draw bindings, and it passed.
- Ran `GraphicsRenderPipelineTests.Execute_SubmitsIndexedDrawPassCommands` and `GraphicsRenderPipelineTests.Rendering_InitializesAndSubmitsGeometryPass` which validate pipeline execution and default geometry pass ownership, and both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e917537118832781062683ce5f0c63)