### PR TITLE
Refactor plugin helpers, update AssetManager construction, and disable unity builds in CMake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -21,7 +21,8 @@
         "CMAKE_LIBRARY_OUTPUT_DIRECTORY": "${sourceDir}/build/${presetName}/bin",
         "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/${presetName}/bin",
         "CMAKE_PDB_OUTPUT_DIRECTORY": "${sourceDir}/build/${presetName}/pdb",
-        "CMAKE_CXX_SCAN_FOR_MODULES": "OFF"
+        "CMAKE_CXX_SCAN_FOR_MODULES": "OFF",
+        "CMAKE_UNITY_BUILD": "OFF"
       },
       "hidden": true
     },
@@ -54,21 +55,15 @@
     },
     {
       "name": "msvc-dev",
-      "displayName": "Toybox (MSVC Dev Fast)",
-      "description": "MSVC local dev preset with unity builds for faster iteration",
-      "inherits": "msvc",
-      "cacheVariables": {
-        "CMAKE_UNITY_BUILD": "ON"
-      }
+      "displayName": "Toybox (MSVC Dev)",
+      "description": "MSVC local debug development preset",
+      "inherits": "msvc"
     },
     {
       "name": "clang-dev",
-      "displayName": "Toybox (Clang Dev Fast)",
-      "description": "Clang local dev preset with unity builds for faster iteration",
-      "inherits": "clang",
-      "cacheVariables": {
-        "CMAKE_UNITY_BUILD": "ON"
-      }
+      "displayName": "Toybox (Clang Dev)",
+      "description": "Clang local debug development preset",
+      "inherits": "clang"
     }
   ],
   "buildPresets": [

--- a/engine/src/systems/app/application.cpp
+++ b/engine/src/systems/app/application.cpp
@@ -54,9 +54,7 @@ namespace tbx
         service_provider.register_service<AssetManager>(std::make_unique<AssetManager>(
             service_provider.get_service<IMessageCoordinator>(),
             service_provider.get_service<SerializationRegistry>(),
-            desc.working_root,
-            {},
-            {}));
+            desc.working_root));
         service_provider.register_service<AppSettings>(std::make_unique<AppSettings>(
             service_provider.get_service<IMessageCoordinator>(),
             false,

--- a/engine/src/systems/plugin_api/plugin_manager.cpp
+++ b/engine/src/systems/plugin_api/plugin_manager.cpp
@@ -15,7 +15,7 @@ namespace tbx
 {
     static constexpr size invalid_plugin_index = std::numeric_limits<size>::max();
 
-    static bool path_contains_directory_token(
+    static bool plugin_manager_path_contains_directory_token(
         const std::filesystem::path& path,
         std::string_view directory_name_lowered)
     {
@@ -287,7 +287,7 @@ namespace tbx
         };
 
         const auto changed_path = _file_ops->resolve(change.path).lexically_normal();
-        if (path_contains_directory_token(changed_path, "resources"))
+        if (plugin_manager_path_contains_directory_token(changed_path, "resources"))
             return;
 
         if (is_plugin_manifest_path(changed_path))

--- a/plugins/sdl_windowing/src/sdl_windowing_plugin.cpp
+++ b/plugins/sdl_windowing/src/sdl_windowing_plugin.cpp
@@ -12,7 +12,7 @@ namespace sdl_windowing
 {
     namespace
     {
-        bool is_wayland_video_driver()
+        bool is_wayland_video_driver_for_plugin()
         {
             const char* video_driver = SDL_GetCurrentVideoDriver();
             return video_driver != nullptr && std::string_view(video_driver) == "wayland";
@@ -23,7 +23,7 @@ namespace sdl_windowing
             if (icon_path.empty())
                 return nullptr;
 
-            if (is_wayland_video_driver())
+            if (is_wayland_video_driver_for_plugin())
                 return nullptr;
 
             SDL_ClearError();

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -78,4 +78,3 @@ endif ()
 unset(BUILD_SHARED_LIBS)
 
 unset(CMAKE_FOLDER)
-


### PR DESCRIPTION
### Motivation
- Normalize and clarify helper function names in plugin code to reduce ambiguity and avoid collisions.
- Update `AssetManager` construction to match a changed constructor signature.
- Disable unity builds by default in CMake presets and simplify dev presets to reflect local debug settings.

### Description
- Renamed `path_contains_directory_token` to `plugin_manager_path_contains_directory_token` and updated its usage in `PluginManager::process_file_change` to improve clarity.
- Renamed `is_wayland_video_driver` to `is_wayland_video_driver_for_plugin` and updated the SDL icon loading path to call the new name in `sdl_windowing_plugin.cpp`.
- Adjusted `Application` initialization to construct `AssetManager` with the single `desc.working_root` argument to match the new constructor signature in `application.cpp`.
- Updated `CMakePresets.json` to add `CMAKE_UNITY_BUILD = OFF` to the base preset and removed per-dev unity overrides while renaming dev preset display names and descriptions.
- Minor cleanup in `thirdparty/CMakeLists.txt` whitespace/formatting at EOF.

### Testing
- Configured and generated build files with the updated presets using CMake presets (`cmake --preset msvc-debug` and `cmake --preset clang-debug`).
- Built the project with Ninja for MSVC and Clang configurations; both builds completed successfully.
- Ran unit tests via `ctest --output-on-failure` after building; all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb98757210832786a26cd9c588076a)