### PR TITLE
Add RenderGraph and RenderGraphBuilder; switch rendering pipeline to consume render snapshots

### DIFF
--- a/engine/include/tbx/systems/graphics/pipeline/render_frame_context.h
+++ b/engine/include/tbx/systems/graphics/pipeline/render_frame_context.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "tbx/systems/ecs/entity_registry.h"
+#include "tbx/systems/graphics/render_graph.h"
 #include "tbx/systems/graphics/resource_manager.h"
 #include "tbx/systems/math/matrices.h"
 #include "tbx/tbx_api.h"
@@ -14,14 +14,14 @@ namespace tbx
     /// Purpose: Per-frame shared data passed through the prepare phase of all render operations.
     /// @details
     /// Input fields are set by the scheduler before the first prepare() call.
-    /// Output fields are written by operations during prepare() and consumed by subsequent operations.
-    /// All Uuid outputs default to invalid; consumers must validate before use.
+    /// Output fields are written by operations during prepare() and consumed by subsequent
+    /// operations. All Uuid outputs default to invalid; consumers must validate before use.
     struct TBX_API RenderFrameContext
     {
         // Inputs — set by the scheduler before prepare begins
         std::reference_wrapper<IGraphicsBackend> backend;
         std::reference_wrapper<GraphicsResourceManager> resource_manager;
-        std::reference_wrapper<EntityRegistry> entity_registry;
+        std::reference_wrapper<const RenderGraph> render_graph;
         Mat4 view_projection = Mat4(1.0F);
         Vec3 camera_position = {};
         uint64 frame_index = 0U;

--- a/engine/include/tbx/systems/graphics/render_graph.h
+++ b/engine/include/tbx/systems/graphics/render_graph.h
@@ -1,25 +1,44 @@
 #pragma once
+#include "tbx/systems/ecs/entity.h"
+#include "tbx/systems/ecs/entity_registry.h"
 #include "tbx/systems/graphics/light.h"
 #include "tbx/systems/graphics/material.h"
+#include "tbx/systems/graphics/mesh.h"
 #include "tbx/systems/graphics/post_processing.h"
 #include "tbx/systems/math/transform.h"
 #include "tbx/tbx_api.h"
 #include "tbx/types/uuid.h"
+#include <functional>
+#include <memory>
 #include <vector>
-
 
 namespace tbx
 {
     /// @brief
-    /// Purpose: Describes one renderable mesh/material pair already uploaded to a graphics backend.
+    /// Purpose: Identifies where renderable geometry comes from before backend resources are
+    /// resolved.
     /// @details
-    /// Ownership: Stores resource identifiers and transform data by value.
+    /// Ownership: Value type. Thread Safety: Safe to copy between threads.
+    enum class RenderGraphGeometrySource
+    {
+        DynamicMesh,
+        StaticMesh
+    };
+
+    /// @brief
+    /// Purpose: Describes one scene renderable captured from ECS for backend-neutral render
+    /// preparation.
+    /// @details
+    /// Ownership: Copies entity, material, static model handle, and transform data by value;
+    /// shares runtime mesh data via std::shared_ptr when source is DynamicMesh.
     /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
     struct TBX_API RenderGraphRenderable
     {
         Uuid entity_uuid = {};
-        Uuid mesh_resource_uuid = {};
-        Uuid material_resource_uuid = {};
+        RenderGraphGeometrySource geometry_source = RenderGraphGeometrySource::DynamicMesh;
+        std::shared_ptr<Mesh> dynamic_mesh = {};
+        Handle static_mesh = {};
+        MaterialInstance material = {};
         Transform transform = {};
         bool is_visible = true;
     };
@@ -77,6 +96,26 @@ namespace tbx
     };
 
     /// @brief
+    /// Purpose: Describes the sky submitted to the render graph and the transform used to place it.
+    /// @details
+    /// Ownership: Stores sky and transform data by value. Defaults to a black sky so every frame
+    /// has deterministic sky state even when no Sky component exists in ECS.
+    /// Thread Safety: Safe for concurrent reads; synchronize mutation externally.
+    struct TBX_API RenderGraphSky
+    {
+        Sky sky = Sky {
+            .material = MaterialInstance(
+                Handle("Materials/Skybox.mat"),
+                MaterialParameterBindings {
+                    MaterialParameter("color", Color::BLACK),
+                    MaterialParameter("emissive", Color::BLACK),
+                    MaterialParameter("color_texture_blend", 0.0F),
+                }),
+        };
+        Transform transform = {};
+    };
+
+    /// @brief
     /// Purpose: Stores backend-neutral scene data for one render submission.
     /// @details
     /// Ownership: Owns all submission lists and scene-level render settings by value.
@@ -88,7 +127,43 @@ namespace tbx
         std::vector<RenderGraphSpotLight> spot_lights = {};
         std::vector<RenderGraphAreaLight> area_lights = {};
         std::vector<RenderGraphDirectionalLight> directional_lights = {};
-        Sky sky = {};
+        RenderGraphSky sky = {};
         PostProcessing post_processing = {};
+    };
+
+    /// @brief
+    /// Purpose: Builds a backend-neutral RenderGraph snapshot from the ECS scene.
+    /// @details
+    /// Ownership: Borrows the entity registry and returns owned render graph snapshots.
+    /// Thread Safety: Not thread-safe; callers should synchronize ECS access externally.
+    class TBX_API RenderGraphBuilder final
+    {
+      public:
+        RenderGraphBuilder(EntityRegistry& registry);
+        ~RenderGraphBuilder() noexcept = default;
+
+      public:
+        RenderGraphBuilder(const RenderGraphBuilder&) = delete;
+        RenderGraphBuilder& operator=(const RenderGraphBuilder&) = delete;
+        RenderGraphBuilder(RenderGraphBuilder&&) noexcept = default;
+        RenderGraphBuilder& operator=(RenderGraphBuilder&&) noexcept = default;
+
+      public:
+        /// @brief
+        /// Purpose: Captures the current ECS render data into a render graph.
+        /// @details
+        /// Ownership: Returns an owned graph snapshot.
+        /// Thread Safety: Not thread-safe; callers should synchronize ECS access externally.
+        RenderGraph build() const;
+
+      private:
+        void append_dynamic_meshes(RenderGraph& graph) const;
+        void append_sky(RenderGraph& graph) const;
+        void append_static_meshes(RenderGraph& graph) const;
+        MaterialInstance get_material(Entity& entity) const;
+
+      private:
+        std::reference_wrapper<EntityRegistry> _registry;
+        MaterialInstance _default_material = MaterialInstance(Handle("Materials/Flat.mat"));
     };
 }

--- a/engine/src/systems/graphics/pipeline/opaque_scene_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/opaque_scene_operation.cpp
@@ -159,8 +159,7 @@ namespace tbx
             if (stride < 3U)
                 return;
 
-            const uint32 source_vertex_count =
-                static_cast<uint32>(mesh.vertices.size() / stride);
+            const uint32 source_vertex_count = static_cast<uint32>(mesh.vertices.size() / stride);
             auto clip_positions = std::vector<Vec4> {};
             clip_positions.reserve(source_vertex_count);
 
@@ -507,11 +506,9 @@ namespace tbx
 
             _fallback_vertex_buffer_size = vertex_size;
         }
-        else if (const auto result = backend.update_buffer(
-                     _fallback_vertex_buffer,
-                     vertices.data(),
-                     vertex_size,
-                     0U);
+        else if (const auto result =
+                     backend
+                         .update_buffer(_fallback_vertex_buffer, vertices.data(), vertex_size, 0U);
                  !result)
         {
             return result;
@@ -617,15 +614,14 @@ namespace tbx
     Result OpaqueSceneOperation::prepare(RenderFrameContext& context)
     {
         _draw_commands.clear();
-        _clear_flags = context.has_skybox ? GraphicsClearFlags::DEPTH
-                                          : GraphicsClearFlags::COLOR_DEPTH;
+        _clear_flags =
+            context.has_skybox ? GraphicsClearFlags::DEPTH : GraphicsClearFlags::COLOR_DEPTH;
 
         auto& backend = context.backend.get();
         auto& resource_manager = context.resource_manager.get();
-        auto& registry = context.entity_registry.get();
+        const RenderGraph& render_graph = context.render_graph.get();
         const uint64 frame_index = context.frame_index;
         const Uuid view_uniform_buffer = context.view_uniform_buffer;
-        const auto default_material = MaterialInstance(Handle("Materials/Flat.mat"));
 
         // -------------------------------------------------------------------
         // Touch resource manager to update LRU access — mark all used materials
@@ -664,8 +660,7 @@ namespace tbx
                 std::vector<GraphicsResourceBinding>& out_textures) -> Result
         {
             auto resolved = ResolvedMaterial {};
-            if (const auto result = resolve_material(material, resource_manager, resolved);
-                !result)
+            if (const auto result = resolve_material(material, resource_manager, resolved); !result)
                 return result;
 
             Uuid uniform_buffer = {};
@@ -695,61 +690,56 @@ namespace tbx
         auto dynamic_batches = std::unordered_map<uint64, DynamicBatch> {};
         auto prepare_result = Result {};
 
-        registry.for_each_with<DynamicMesh, Transform>(
-            [&](Entity& entity)
+        for (const auto& renderable : render_graph.renderables)
+        {
+            if (!prepare_result)
+                break;
+            if (!renderable.is_visible
+                || renderable.geometry_source != RenderGraphGeometrySource::DynamicMesh)
+                continue;
+
+            const std::shared_ptr<Mesh>& mesh_data = renderable.dynamic_mesh;
+            if (!mesh_data)
+                continue;
+
+            const Mat4 model_to_world = build_transform_matrix(renderable.transform);
+
+            if (!can_render_mesh_directly(*mesh_data))
             {
-                if (!prepare_result)
-                    return;
+                touch_material(renderable.material);
+                append_mesh_geometry(
+                    *mesh_data,
+                    context.view_projection * model_to_world,
+                    fallback_geometry);
+                continue;
+            }
 
-                const auto& dynamic_mesh = entity.get_component<DynamicMesh>();
-                const std::shared_ptr<Mesh>& mesh_data = dynamic_mesh.data;
-                if (!mesh_data)
-                    return;
+            Uuid pipeline = {};
+            uint64 material_key = 0U;
+            Uuid uniform_buffer = {};
+            auto textures = std::vector<GraphicsResourceBinding> {};
+            prepare_result = resolve_and_store_material(
+                renderable.material,
+                pipeline,
+                material_key,
+                uniform_buffer,
+                textures);
+            if (!prepare_result)
+                break;
 
-                const Mat4 model_to_world =
-                    build_transform_matrix(get_world_space_transform(entity));
-
-                if (!can_render_mesh_directly(*mesh_data))
-                {
-                    if (entity.has_component<MaterialInstance>())
-                        touch_material(entity.get_component<MaterialInstance>());
-                    append_mesh_geometry(
-                        *mesh_data,
-                        context.view_projection * model_to_world,
-                        fallback_geometry);
-                    return;
-                }
-
-                const MaterialInstance& material_instance = entity.has_component<MaterialInstance>()
-                    ? entity.get_component<MaterialInstance>()
-                    : default_material;
-
-                Uuid pipeline = {};
-                uint64 material_key = 0U;
-                Uuid uniform_buffer = {};
-                auto textures = std::vector<GraphicsResourceBinding> {};
-                prepare_result = resolve_and_store_material(
-                    material_instance,
-                    pipeline,
-                    material_key,
-                    uniform_buffer,
-                    textures);
-                if (!prepare_result)
-                    return;
-
-                const uint64 mesh_key = make_mesh_cache_key(mesh_data);
-                const uint64 batch_key = make_dynamic_batch_key(mesh_key, material_key);
-                auto& batch = dynamic_batches[batch_key];
-                if (!batch.mesh_data)
-                {
-                    batch.mesh_data = mesh_data;
-                    batch.pipeline = pipeline;
-                    batch.material_key = material_key;
-                    batch.material_uniform_buffer = uniform_buffer;
-                    batch.textures = std::move(textures);
-                }
-                batch.transforms.push_back(model_to_world);
-            });
+            const uint64 mesh_key = make_mesh_cache_key(mesh_data);
+            const uint64 batch_key = make_dynamic_batch_key(mesh_key, material_key);
+            auto& batch = dynamic_batches[batch_key];
+            if (!batch.mesh_data)
+            {
+                batch.mesh_data = mesh_data;
+                batch.pipeline = pipeline;
+                batch.material_key = material_key;
+                batch.material_uniform_buffer = uniform_buffer;
+                batch.textures = std::move(textures);
+            }
+            batch.transforms.push_back(model_to_world);
+        }
 
         if (!prepare_result)
             return prepare_result;
@@ -760,61 +750,57 @@ namespace tbx
 
         auto static_batches = std::unordered_map<uint64, StaticBatch> {};
 
-        registry.for_each_with<StaticMesh, Transform>(
-            [&](Entity& entity)
+        for (const auto& renderable : render_graph.renderables)
+        {
+            if (!prepare_result)
+                break;
+            if (!renderable.is_visible
+                || renderable.geometry_source != RenderGraphGeometrySource::StaticMesh)
+                continue;
+            if (!renderable.static_mesh.is_valid())
+                continue;
+
+            auto model_resource = GraphicsModelResource {};
+            prepare_result = resource_manager.load_model(renderable.static_mesh, model_resource);
+            if (!prepare_result)
+                break;
+
+            const Mat4 model_to_world = build_transform_matrix(renderable.transform);
+
+            Uuid pipeline = {};
+            uint64 material_key = 0U;
+            Uuid uniform_buffer = {};
+            auto textures = std::vector<GraphicsResourceBinding> {};
+            prepare_result = resolve_and_store_material(
+                renderable.material,
+                pipeline,
+                material_key,
+                uniform_buffer,
+                textures);
+            if (!prepare_result)
+                break;
+
+            for (const auto& mesh : model_resource.meshes)
             {
-                if (!prepare_result)
-                    return;
-
-                const auto& static_mesh = entity.get_component<StaticMesh>();
-                if (!static_mesh.handle.is_valid())
-                    return;
-
-                auto model_resource = GraphicsModelResource {};
-                prepare_result = resource_manager.load_model(static_mesh.handle, model_resource);
-                if (!prepare_result)
-                    return;
-
-                const Mat4 model_to_world =
-                    build_transform_matrix(get_world_space_transform(entity));
-                const MaterialInstance& material_instance = entity.has_component<MaterialInstance>()
-                    ? entity.get_component<MaterialInstance>()
-                    : default_material;
-
-                Uuid pipeline = {};
-                uint64 material_key = 0U;
-                Uuid uniform_buffer = {};
-                auto textures = std::vector<GraphicsResourceBinding> {};
-                prepare_result = resolve_and_store_material(
-                    material_instance,
-                    pipeline,
-                    material_key,
-                    uniform_buffer,
-                    textures);
-                if (!prepare_result)
-                    return;
-
-                for (const auto& mesh : model_resource.meshes)
+                const uint64 batch_key = make_static_batch_key(
+                    mesh.vertex_buffer,
+                    mesh.index_buffer,
+                    mesh.index_count,
+                    material_key);
+                auto& batch = static_batches[batch_key];
+                if (!batch.vertex_buffer.is_valid())
                 {
-                    const uint64 batch_key = make_static_batch_key(
-                        mesh.vertex_buffer,
-                        mesh.index_buffer,
-                        mesh.index_count,
-                        material_key);
-                    auto& batch = static_batches[batch_key];
-                    if (!batch.vertex_buffer.is_valid())
-                    {
-                        batch.vertex_buffer = mesh.vertex_buffer;
-                        batch.index_buffer = mesh.index_buffer;
-                        batch.index_count = mesh.index_count;
-                        batch.pipeline = pipeline;
-                        batch.material_key = material_key;
-                        batch.material_uniform_buffer = uniform_buffer;
-                        batch.textures = textures;
-                    }
-                    batch.transforms.push_back(model_to_world);
+                    batch.vertex_buffer = mesh.vertex_buffer;
+                    batch.index_buffer = mesh.index_buffer;
+                    batch.index_count = mesh.index_count;
+                    batch.pipeline = pipeline;
+                    batch.material_key = material_key;
+                    batch.material_uniform_buffer = uniform_buffer;
+                    batch.textures = textures;
                 }
-            });
+                batch.transforms.push_back(model_to_world);
+            }
+        }
 
         if (!prepare_result)
             return prepare_result;
@@ -844,11 +830,8 @@ namespace tbx
             _mesh_last_access[mesh_key] = frame_index;
 
             Uuid instance_buffer = {};
-            if (const auto result = ensure_instance_buffer(
-                    backend,
-                    batch_key,
-                    batch.transforms,
-                    instance_buffer);
+            if (const auto result =
+                    ensure_instance_buffer(backend, batch_key, batch.transforms, instance_buffer);
                 !result)
                 return result;
 
@@ -877,8 +860,7 @@ namespace tbx
                             .primitive_type = GraphicsPrimitiveType::TRIANGLES,
                             .index_type = GraphicsIndexType::UINT32,
                             .index_count = index_count,
-                            .instance_count =
-                                static_cast<uint32>(batch.transforms.size()),
+                            .instance_count = static_cast<uint32>(batch.transforms.size()),
                         },
                 });
         }
@@ -889,11 +871,8 @@ namespace tbx
                 continue;
 
             Uuid instance_buffer = {};
-            if (const auto result = ensure_instance_buffer(
-                    backend,
-                    batch_key,
-                    batch.transforms,
-                    instance_buffer);
+            if (const auto result =
+                    ensure_instance_buffer(backend, batch_key, batch.transforms, instance_buffer);
                 !result)
                 return result;
 
@@ -922,8 +901,7 @@ namespace tbx
                             .primitive_type = GraphicsPrimitiveType::TRIANGLES,
                             .index_type = GraphicsIndexType::UINT32,
                             .index_count = batch.index_count,
-                            .instance_count =
-                                static_cast<uint32>(batch.transforms.size()),
+                            .instance_count = static_cast<uint32>(batch.transforms.size()),
                         },
                 });
         }
@@ -959,8 +937,7 @@ namespace tbx
                         GraphicsDrawIndexedDesc {
                             .primitive_type = GraphicsPrimitiveType::TRIANGLES,
                             .index_type = GraphicsIndexType::UINT32,
-                            .index_count =
-                                static_cast<uint32>(fallback_geometry.indices.size()),
+                            .index_count = static_cast<uint32>(fallback_geometry.indices.size()),
                             .instance_count = 1U,
                         },
                 });
@@ -970,9 +947,7 @@ namespace tbx
         return {};
     }
 
-    Result OpaqueSceneOperation::execute(
-        IGraphicsBackend& backend,
-        const CancellationToken& token)
+    Result OpaqueSceneOperation::execute(IGraphicsBackend& backend, const CancellationToken& token)
     {
         if (token && token.is_cancelled())
             return Result(false, "OpaqueSceneOperation cancelled.");

--- a/engine/src/systems/graphics/pipeline/skybox_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/skybox_operation.cpp
@@ -1,10 +1,9 @@
 #include "tbx/systems/graphics/pipeline/skybox_operation.h"
 #include "render_material_helpers.h"
-#include "tbx/systems/ecs/entity.h"
-#include "tbx/systems/graphics/camera.h"
 #include "tbx/systems/graphics/material.h"
 #include "tbx/systems/graphics/mesh.h"
 #include "tbx/systems/graphics/pipeline/render_frame_context.h"
+#include "tbx/systems/graphics/render_graph.h"
 #include "tbx/systems/math/matrices.h"
 #include <utility>
 
@@ -120,26 +119,18 @@ namespace tbx
     {
         _ready = false;
 
-        auto sky_material = std::optional<MaterialInstance> {};
-        auto sky_transform = Transform {};
-        context.entity_registry.get().for_each_with<Sky>(
-            [&sky_material, &sky_transform](Entity& entity)
-            {
-                if (sky_material.has_value())
-                    return;
-                sky_material = entity.get_component<Sky>().material;
-                if (entity.has_component<Transform>())
-                    sky_transform = get_world_space_transform(entity);
-            });
-
-        if (!sky_material.has_value() || !sky_material->get_handle().is_valid())
+        const RenderGraph& render_graph = context.render_graph.get();
+        if (!render_graph.sky.sky.material.get_handle().is_valid())
             return {};
+
+        const MaterialInstance& sky_material = render_graph.sky.sky.material;
+        const Transform& sky_transform = render_graph.sky.transform;
 
         auto& backend = context.backend.get();
         auto& resource_manager = context.resource_manager.get();
 
         auto resolved = ResolvedMaterial {};
-        if (const auto result = resolve_material(*sky_material, resource_manager, resolved);
+        if (const auto result = resolve_material(sky_material, resource_manager, resolved);
             !result)
             return result;
 

--- a/engine/src/systems/graphics/render_graph.cpp
+++ b/engine/src/systems/graphics/render_graph.cpp
@@ -1,0 +1,83 @@
+#include "tbx/systems/graphics/render_graph.h"
+#include "tbx/systems/ecs/entity.h"
+
+namespace tbx
+{
+    RenderGraphBuilder::RenderGraphBuilder(EntityRegistry& registry)
+        : _registry(registry)
+    {
+    }
+
+    RenderGraph RenderGraphBuilder::build() const
+    {
+        auto graph = RenderGraph {};
+        append_sky(graph);
+        append_dynamic_meshes(graph);
+        append_static_meshes(graph);
+        return graph;
+    }
+
+    void RenderGraphBuilder::append_dynamic_meshes(RenderGraph& graph) const
+    {
+        _registry.get().for_each_with<DynamicMesh, Transform>(
+            [this, &graph](Entity& entity)
+            {
+                const auto& dynamic_mesh = entity.get_component<DynamicMesh>();
+                if (!dynamic_mesh.data)
+                    return;
+
+                graph.renderables.push_back(
+                    RenderGraphRenderable {
+                        .entity_uuid = entity.get_id(),
+                        .geometry_source = RenderGraphGeometrySource::DynamicMesh,
+                        .dynamic_mesh = dynamic_mesh.data,
+                        .material = get_material(entity),
+                        .transform = get_world_space_transform(entity),
+                    });
+            });
+    }
+
+    void RenderGraphBuilder::append_sky(RenderGraph& graph) const
+    {
+        auto found = false;
+        _registry.get().for_each_with<Sky>(
+            [&graph, &found](Entity& entity)
+            {
+                if (found)
+                    return;
+
+                graph.sky.sky = entity.get_component<Sky>();
+                if (entity.has_component<Transform>())
+                    graph.sky.transform = get_world_space_transform(entity);
+                found = true;
+            });
+    }
+
+    void RenderGraphBuilder::append_static_meshes(RenderGraph& graph) const
+    {
+        _registry.get().for_each_with<StaticMesh, Transform>(
+            [this, &graph](Entity& entity)
+            {
+                const auto& static_mesh = entity.get_component<StaticMesh>();
+                if (!static_mesh.handle.is_valid())
+                    return;
+
+                graph.renderables.push_back(
+                    RenderGraphRenderable {
+                        .entity_uuid = entity.get_id(),
+                        .geometry_source = RenderGraphGeometrySource::StaticMesh,
+                        .static_mesh = static_mesh.handle,
+                        .material = get_material(entity),
+                        .transform = get_world_space_transform(entity),
+                    });
+            });
+    }
+
+    MaterialInstance RenderGraphBuilder::get_material(Entity& entity) const
+    {
+        if (entity.has_component<MaterialInstance>())
+            return entity.get_component<MaterialInstance>();
+
+        return _default_material;
+    }
+}

--- a/engine/src/systems/graphics/rendering.cpp
+++ b/engine/src/systems/graphics/rendering.cpp
@@ -6,42 +6,45 @@
 #include "tbx/systems/graphics/pipeline/render_frame_context.h"
 #include "tbx/systems/graphics/pipeline/skybox_operation.h"
 #include "tbx/systems/graphics/pipeline/view_uniform_operation.h"
+#include "tbx/systems/graphics/render_graph.h"
 #include "tbx/systems/math/matrices.h"
 #include <functional>
 #include <utility>
 
 namespace tbx
 {
-    namespace
+    /// @brief
+    /// Purpose: Stores the camera and transform selected for the current render frame.
+    /// @details
+    /// Ownership: Value snapshot. Thread Safety: Safe for concurrent reads.
+    struct RenderView
     {
-        struct RenderView
-        {
-            Camera camera = {};
-            Transform transform = {};
+        Camera camera = {};
+        Transform transform = {};
+    };
+
+    static RenderView find_render_camera(EntityRegistry& registry, const Size resolution)
+    {
+        auto view = RenderView {
+            .transform = Transform(Vec3(0.0F, 2.0F, 8.0F)),
         };
+        auto found = false;
+        registry.for_each_with<Camera, Transform>(
+            [&view, &found](Entity& entity)
+            {
+                if (found)
+                    return;
+                view.camera = entity.get_component<Camera>();
+                view.transform = get_world_space_transform(entity);
+                found = true;
+            });
 
-        RenderView find_render_camera(EntityRegistry& registry, const Size resolution)
-        {
-            auto view = RenderView {
-                .transform = Transform(Vec3(0.0F, 2.0F, 8.0F)),
-            };
-            auto found = false;
-            registry.for_each_with<Camera, Transform>(
-                [&view, &found](Entity& entity)
-                {
-                    if (found)
-                        return;
-                    view.camera = entity.get_component<Camera>();
-                    view.transform = get_world_space_transform(entity);
-                    found = true;
-                });
-
-            const float aspect = resolution.height == 0U
+        const float aspect =
+            resolution.height == 0U
                 ? 1.0F
                 : static_cast<float>(resolution.width) / static_cast<float>(resolution.height);
-            view.camera.set_aspect(aspect);
-            return view;
-        }
+        view.camera.set_aspect(aspect);
+        return view;
     }
 
     Rendering::Rendering(
@@ -88,6 +91,7 @@ namespace tbx
 
         const Size resolution = get_render_resolution();
         const RenderView render_view = find_render_camera(_entity_registry.get(), resolution);
+        auto render_graph = RenderGraphBuilder(_entity_registry.get()).build();
         const Mat4 view_projection = render_view.camera.get_view_projection_matrix(
             render_view.transform.position,
             render_view.transform.rotation);
@@ -98,16 +102,14 @@ namespace tbx
 
         if (const auto result = begin_frame_and_view(render_view.camera, viewport); !result)
         {
-            TBX_TRACE_WARNING(
-                "Toybox renderer frame begin failed: {}",
-                result.get_report());
+            TBX_TRACE_WARNING("Toybox renderer frame begin failed: {}", result.get_report());
             return;
         }
 
         auto context = RenderFrameContext {
             .backend = _backend,
             .resource_manager = *_resource_manager,
-            .entity_registry = _entity_registry,
+            .render_graph = render_graph,
             .view_projection = view_projection,
             .camera_position = render_view.transform.position,
             .frame_index = _render_frame,
@@ -118,12 +120,10 @@ namespace tbx
             auto& backend = _backend.get();
             backend.end_view();
             backend.end_frame();
-            TBX_TRACE_WARNING(
-                "Toybox renderer frame submission failed: {}",
-                failure.get_report());
+            TBX_TRACE_WARNING("Toybox renderer frame submission failed: {}", failure.get_report());
         };
 
-        // Phase 1 — prepare: CPU work, resource uploads, entity queries
+        // Phase 1 — prepare: CPU work, resource uploads, render graph consumption
         for (auto& operation : _operations)
         {
             if (const auto result = operation->prepare(context); !result)
@@ -136,7 +136,8 @@ namespace tbx
         // Phase 2 — execute: GPU commands, one pass per operation
         for (auto& operation : _operations)
         {
-            if (const auto result = operation->execute(_backend.get(), CancellationToken {}); !result)
+            if (const auto result = operation->execute(_backend.get(), CancellationToken {});
+                !result)
             {
                 abort_frame(result);
                 return;
@@ -145,9 +146,7 @@ namespace tbx
 
         if (const auto result = end_view_and_frame(); !result)
         {
-            TBX_TRACE_WARNING(
-                "Toybox renderer frame end failed: {}",
-                result.get_report());
+            TBX_TRACE_WARNING("Toybox renderer frame end failed: {}", result.get_report());
         }
     }
 


### PR DESCRIPTION
### Motivation
- Decouple ECS queries from the render prepare phase by capturing a backend-neutral scene snapshot for use by rendering operations. 
- Provide a deterministic sky default and unify handling of dynamic vs static mesh sources for preparation and batching. 
- Reduce direct ECS access during per-frame prepare so the scheduler can build the scene once and operations can safely consume the snapshot.

### Description
- Added `RenderGraph`, `RenderGraphRenderable`, `RenderGraphSky`, `RenderGraphGeometrySource`, and `RenderGraphBuilder` in `render_graph.h` and `render_graph.cpp` to represent and build a backend-neutral scene snapshot. 
- Changed `RenderFrameContext` to carry a `std::reference_wrapper<const RenderGraph>` (`render_graph`) instead of a direct `EntityRegistry` reference. 
- Updated `Rendering::render()` to construct a `RenderGraph` via `RenderGraphBuilder` and pass the snapshot into the per-frame `RenderFrameContext`. 
- Refactored `OpaqueSceneOperation` and `SkyboxOperation` to consume `render_graph.renderables` and `render_graph.sky` instead of performing ECS queries directly, and applied small formatting and API-call style cleanups across the pipeline.

### Testing
- Built the project with the updated sources and headers successfully without compiler errors. 
- Executed the renderer's automated test suite and graphics pipeline smoke tests, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9c11ae9483278b83078ba43ce926)