### PR TITLE
Refactor render command execution, add pipeline config and operation debug info

### DIFF
--- a/engine/include/tbx/systems/graphics/pipeline/opaque_scene_operation.h
+++ b/engine/include/tbx/systems/graphics/pipeline/opaque_scene_operation.h
@@ -28,6 +28,7 @@ namespace tbx
         OpaqueSceneOperation(OpaqueSceneOperation&&) noexcept = default;
         OpaqueSceneOperation& operator=(OpaqueSceneOperation&&) noexcept = default;
 
+        RenderOperationDebugInfo get_debug_info() const override;
         Result prepare(RenderFrameContext& context) override;
         Result execute(IGraphicsBackend& backend, const CancellationToken& token) override;
         void release(IGraphicsBackend& backend) override;

--- a/engine/include/tbx/systems/graphics/pipeline/render_command_executor.h
+++ b/engine/include/tbx/systems/graphics/pipeline/render_command_executor.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "tbx/interfaces/graphics_backend.h"
+#include "tbx/systems/graphics/pipeline/render_pass.h"
+#include "tbx/tbx_api.h"
+#include "tbx/utils/result.h"
+
+namespace tbx
+{
+    /// @brief
+    /// Purpose: Executes prepared draw commands by applying their shared binding layout before
+    /// issuing a draw.
+    /// @details
+    /// Ownership: Does not own command resources. The backend must keep referenced resources alive.
+    /// Thread Safety: Not thread-safe; call from the owning render thread.
+    class TBX_API RenderCommandExecutor
+    {
+      public:
+        Result execute_draw(IGraphicsBackend& backend, const GraphicsDrawCommand& command) const;
+        Result execute_indexed_draw(
+            IGraphicsBackend& backend,
+            const GraphicsIndexedDrawCommand& command) const;
+
+      private:
+        Result bind_common_resources(
+            IGraphicsBackend& backend,
+            const std::vector<GraphicsResourceBinding>& uniform_buffers,
+            const std::vector<GraphicsResourceBinding>& storage_buffers,
+            const std::vector<GraphicsResourceBinding>& textures,
+            const std::vector<GraphicsResourceBinding>& samplers) const;
+
+        Result bind_vertex_buffers(
+            IGraphicsBackend& backend,
+            const std::vector<GraphicsResourceBinding>& vertex_buffers) const;
+    };
+}

--- a/engine/include/tbx/systems/graphics/pipeline/render_operation.h
+++ b/engine/include/tbx/systems/graphics/pipeline/render_operation.h
@@ -2,6 +2,7 @@
 #include "tbx/systems/async/cancellation_token.h"
 #include "tbx/tbx_api.h"
 #include "tbx/utils/result.h"
+#include <string>
 
 namespace tbx
 {
@@ -9,7 +10,16 @@ namespace tbx
     struct RenderFrameContext;
 
     /// @brief
-    /// Purpose: Defines a self-contained unit of rendering work with explicit prepare and execute phases.
+    /// Purpose: Describes render operation identity for diagnostics and pipeline composition.
+    struct TBX_API RenderOperationDebugInfo
+    {
+        std::string debug_name = "Unnamed Render Operation";
+        std::string category = "Render";
+    };
+
+    /// @brief
+    /// Purpose: Defines a self-contained unit of rendering work with explicit prepare and execute
+    /// phases.
     /// @details
     /// Ownership: Owns all GPU resource handles it requires. Releases them via release().
     /// Thread Safety: Not thread-safe; call from the owning render thread.
@@ -23,14 +33,19 @@ namespace tbx
         IRenderOperation& operator=(IRenderOperation&&) noexcept = default;
 
         /// @brief
+        /// Purpose: Returns debug info for logs, tooling, and debug labels.
+        virtual RenderOperationDebugInfo get_debug_info() const = 0;
+
+        /// @brief
         /// Purpose: CPU phase — queries scene state, uploads or updates GPU resources.
         /// @details
-        /// Reads from context (camera, frame index) and writes outputs back (e.g. view_uniform_buffer).
-        /// Must be called after begin_frame and before execute.
+        /// Reads from context (camera, frame index) and writes outputs back (e.g.
+        /// view_uniform_buffer). Must be called after begin_frame and before execute.
         virtual Result prepare(RenderFrameContext& context) = 0;
 
         /// @brief
-        /// Purpose: GPU phase — opens a render pass, binds resources, issues draw calls, closes the pass.
+        /// Purpose: GPU phase — opens a render pass, binds resources, issues draw calls, closes the
+        /// pass.
         /// @details
         /// Uses only data stored during prepare(); does not read from the context.
         virtual Result execute(IGraphicsBackend& backend, const CancellationToken& token) = 0;

--- a/engine/include/tbx/systems/graphics/pipeline/render_pipeline_config.h
+++ b/engine/include/tbx/systems/graphics/pipeline/render_pipeline_config.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "tbx/systems/graphics/pipeline/render_operation.h"
+#include "tbx/tbx_api.h"
+#include <memory>
+#include <vector>
+
+namespace tbx
+{
+    /// @brief
+    /// Purpose: Declares the ordered render operations that make up the scene rendering pipeline.
+    struct TBX_API RenderPipelineConfig
+    {
+        std::vector<std::unique_ptr<IRenderOperation>> operations = {};
+
+        static RenderPipelineConfig standard();
+    };
+}

--- a/engine/include/tbx/systems/graphics/pipeline/skybox_operation.h
+++ b/engine/include/tbx/systems/graphics/pipeline/skybox_operation.h
@@ -12,10 +12,10 @@ namespace tbx
     /// @brief
     /// Purpose: Renders the sky dome if a Sky component is present in the scene.
     /// @details
-    /// Ownership: Owns all skybox GPU resources — geometry, instance transform, and material uniform buffers.
-    /// Geometry is uploaded once; instance and material buffers are updated per-frame as needed.
-    /// Interaction: Sets context.has_skybox during prepare() so subsequent operations can skip their
-    /// color clear.
+    /// Ownership: Owns all skybox GPU resources — geometry, instance transform, and material
+    /// uniform buffers. Geometry is uploaded once; instance and material buffers are updated
+    /// per-frame as needed. Interaction: Sets context.has_skybox during prepare() so subsequent
+    /// operations can skip their color clear.
     class TBX_API SkyboxOperation final : public IRenderOperation
     {
       public:
@@ -24,6 +24,7 @@ namespace tbx
         SkyboxOperation(SkyboxOperation&&) noexcept = default;
         SkyboxOperation& operator=(SkyboxOperation&&) noexcept = default;
 
+        RenderOperationDebugInfo get_debug_info() const override;
         Result prepare(RenderFrameContext& context) override;
         Result execute(IGraphicsBackend& backend, const CancellationToken& token) override;
         void release(IGraphicsBackend& backend) override;

--- a/engine/include/tbx/systems/graphics/pipeline/view_uniform_operation.h
+++ b/engine/include/tbx/systems/graphics/pipeline/view_uniform_operation.h
@@ -19,6 +19,7 @@ namespace tbx
         ViewUniformOperation(ViewUniformOperation&&) noexcept = default;
         ViewUniformOperation& operator=(ViewUniformOperation&&) noexcept = default;
 
+        RenderOperationDebugInfo get_debug_info() const override;
         Result prepare(RenderFrameContext& context) override;
         Result execute(IGraphicsBackend& backend, const CancellationToken& token) override;
         void release(IGraphicsBackend& backend) override;

--- a/engine/src/systems/graphics/pipeline/opaque_scene_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/opaque_scene_operation.cpp
@@ -6,6 +6,7 @@
 #include "tbx/systems/graphics/material.h"
 #include "tbx/systems/graphics/mesh.h"
 #include "tbx/systems/graphics/model.h"
+#include "tbx/systems/graphics/pipeline/render_command_executor.h"
 #include "tbx/systems/graphics/pipeline/render_frame_context.h"
 #include "tbx/systems/graphics/shader.h"
 #include "tbx/systems/math/matrices.h"
@@ -17,289 +18,292 @@
 
 namespace tbx
 {
+    RenderOperationDebugInfo OpaqueSceneOperation::get_debug_info() const
+    {
+        auto debug_info = RenderOperationDebugInfo();
+        debug_info.debug_name = "Toybox Opaque Scene Operation";
+        debug_info.category = "Scene Rendering";
+        return debug_info;
+    }
+
     // ---------------------------------------------------------------------------
     // CPU-side geometry clipping (fallback for non-standard mesh strides)
     // ---------------------------------------------------------------------------
 
-    namespace
+    struct GeometryBuildResult
     {
-        struct GeometryBuildResult
-        {
-            std::vector<float> vertices = {};
-            std::vector<uint32> indices = {};
-        };
+        std::vector<float> vertices = {};
+        std::vector<uint32> indices = {};
+    };
 
-        float get_clip_plane_distance(const Vec4& position, const uint32 plane_index)
+    static float get_clip_plane_distance(const Vec4& position, const uint32 plane_index)
+    {
+        switch (plane_index)
         {
-            switch (plane_index)
-            {
-                case 0U:
-                    return position.x + position.w;
-                case 1U:
-                    return position.w - position.x;
-                case 2U:
-                    return position.y + position.w;
-                case 3U:
-                    return position.w - position.y;
-                case 4U:
-                    return position.z + position.w;
-                case 5U:
-                    return position.w - position.z;
-                default:
-                    return 0.0F;
-            }
+            case 0U:
+                return position.x + position.w;
+            case 1U:
+                return position.w - position.x;
+            case 2U:
+                return position.y + position.w;
+            case 3U:
+                return position.w - position.y;
+            case 4U:
+                return position.z + position.w;
+            case 5U:
+                return position.w - position.z;
+            default:
+                return 0.0F;
         }
+    }
 
-        Vec4 interpolate_clip_position(
-            const Vec4& start,
-            const Vec4& end,
-            const float start_distance,
-            const float end_distance)
-        {
-            const float denominator = start_distance - end_distance;
-            if (std::abs(denominator) <= 0.000001F)
-                return start;
-            const float t = start_distance / denominator;
-            return start + ((end - start) * t);
-        }
+    static Vec4 interpolate_clip_position(
+        const Vec4& start,
+        const Vec4& end,
+        const float start_distance,
+        const float end_distance)
+    {
+        const float denominator = start_distance - end_distance;
+        if (std::abs(denominator) <= 0.000001F)
+            return start;
+        const float t = start_distance / denominator;
+        return start + ((end - start) * t);
+    }
 
-        std::vector<Vec4> clip_polygon_against_plane(
-            const std::vector<Vec4>& polygon,
-            const uint32 plane_index)
-        {
-            auto clipped = std::vector<Vec4> {};
-            if (polygon.empty())
-                return clipped;
-
-            clipped.reserve(polygon.size() + 1U);
-            Vec4 previous = polygon.back();
-            float previous_distance = get_clip_plane_distance(previous, plane_index);
-            bool previous_inside = previous_distance >= 0.0F;
-
-            for (const Vec4& current : polygon)
-            {
-                const float current_distance = get_clip_plane_distance(current, plane_index);
-                const bool current_inside = current_distance >= 0.0F;
-
-                if (current_inside != previous_inside)
-                {
-                    clipped.push_back(interpolate_clip_position(
-                        previous,
-                        current,
-                        previous_distance,
-                        current_distance));
-                }
-                if (current_inside)
-                    clipped.push_back(current);
-
-                previous = current;
-                previous_distance = current_distance;
-                previous_inside = current_inside;
-            }
+    static std::vector<Vec4> clip_polygon_against_plane(
+        const std::vector<Vec4>& polygon,
+        const uint32 plane_index)
+    {
+        auto clipped = std::vector<Vec4> {};
+        if (polygon.empty())
             return clipped;
-        }
 
-        void append_projected_vertex(const Vec4& clip_position, GeometryBuildResult& geometry)
-        {
-            const float inverse_w =
-                std::abs(clip_position.w) <= 0.000001F ? 1.0F : 1.0F / clip_position.w;
-            geometry.vertices.push_back(clip_position.x * inverse_w);
-            geometry.vertices.push_back(clip_position.y * inverse_w);
-            geometry.vertices.push_back(clip_position.z * inverse_w);
-        }
+        clipped.reserve(polygon.size() + 1U);
+        Vec4 previous = polygon.back();
+        float previous_distance = get_clip_plane_distance(previous, plane_index);
+        bool previous_inside = previous_distance >= 0.0F;
 
-        void append_clipped_triangle(
-            const Vec4& v0,
-            const Vec4& v1,
-            const Vec4& v2,
-            GeometryBuildResult& geometry)
+        for (const Vec4& current : polygon)
         {
-            auto polygon = std::vector<Vec4> {v0, v1, v2};
-            for (uint32 plane = 0U; plane < 6U; ++plane)
+            const float current_distance = get_clip_plane_distance(current, plane_index);
+            const bool current_inside = current_distance >= 0.0F;
+
+            if (current_inside != previous_inside)
             {
-                polygon = clip_polygon_against_plane(polygon, plane);
-                if (polygon.size() < 3U)
-                    return;
+                clipped.push_back(interpolate_clip_position(
+                    previous,
+                    current,
+                    previous_distance,
+                    current_distance));
             }
+            if (current_inside)
+                clipped.push_back(current);
 
-            for (uint32 i = 1U; i + 1U < polygon.size(); ++i)
-            {
-                const uint32 base = static_cast<uint32>(geometry.vertices.size() / 3U);
-                append_projected_vertex(polygon[0U], geometry);
-                append_projected_vertex(polygon[i], geometry);
-                append_projected_vertex(polygon[i + 1U], geometry);
-                geometry.indices.push_back(base);
-                geometry.indices.push_back(base + 1U);
-                geometry.indices.push_back(base + 2U);
-            }
+            previous = current;
+            previous_distance = current_distance;
+            previous_inside = current_inside;
         }
+        return clipped;
+    }
 
-        uint32 get_vertex_stride_float_count(const Mesh& mesh)
-        {
-            const uint32 stride_bytes = mesh.vertices.layout.stride;
-            return stride_bytes == 0U ? 16U : stride_bytes / static_cast<uint32>(sizeof(float));
-        }
+    static void append_projected_vertex(const Vec4& clip_position, GeometryBuildResult& geometry)
+    {
+        const float inverse_w =
+            std::abs(clip_position.w) <= 0.000001F ? 1.0F : 1.0F / clip_position.w;
+        geometry.vertices.push_back(clip_position.x * inverse_w);
+        geometry.vertices.push_back(clip_position.y * inverse_w);
+        geometry.vertices.push_back(clip_position.z * inverse_w);
+    }
 
-        bool can_render_mesh_directly(const Mesh& mesh)
+    static void append_clipped_triangle(
+        const Vec4& v0,
+        const Vec4& v1,
+        const Vec4& v2,
+        GeometryBuildResult& geometry)
+    {
+        auto polygon = std::vector<Vec4> {v0, v1, v2};
+        for (uint32 plane = 0U; plane < 6U; ++plane)
         {
-            constexpr uint32 model_pipeline_stride = 16U;
-            return !mesh.vertices.empty() && !mesh.indices.empty()
-                   && get_vertex_stride_float_count(mesh) == model_pipeline_stride;
-        }
-
-        void append_mesh_geometry(
-            const Mesh& mesh,
-            const Mat4& world_to_clip,
-            GeometryBuildResult& geometry)
-        {
-            if (mesh.vertices.empty() || mesh.indices.empty())
+            polygon = clip_polygon_against_plane(polygon, plane);
+            if (polygon.size() < 3U)
                 return;
-
-            const uint32 stride = get_vertex_stride_float_count(mesh);
-            if (stride < 3U)
-                return;
-
-            const uint32 source_vertex_count = static_cast<uint32>(mesh.vertices.size() / stride);
-            auto clip_positions = std::vector<Vec4> {};
-            clip_positions.reserve(source_vertex_count);
-
-            for (uint32 vertex_index = 0U; vertex_index < source_vertex_count; ++vertex_index)
-            {
-                const uint32 offset = vertex_index * stride;
-                const Vec4 local = Vec4(
-                    mesh.vertices.vertices[offset],
-                    mesh.vertices.vertices[offset + 1U],
-                    mesh.vertices.vertices[offset + 2U],
-                    1.0F);
-                clip_positions.push_back(world_to_clip * local);
-            }
-
-            for (uint32 index_offset = 0U; index_offset + 2U < mesh.indices.size();
-                 index_offset += 3U)
-            {
-                const uint32 i0 = mesh.indices[index_offset];
-                const uint32 i1 = mesh.indices[index_offset + 1U];
-                const uint32 i2 = mesh.indices[index_offset + 2U];
-                if (i0 >= source_vertex_count || i1 >= source_vertex_count
-                    || i2 >= source_vertex_count)
-                    continue;
-
-                append_clipped_triangle(
-                    clip_positions[i0],
-                    clip_positions[i1],
-                    clip_positions[i2],
-                    geometry);
-            }
         }
 
-        // ---------------------------------------------------------------------------
-        // Fallback pipeline definition
-        // ---------------------------------------------------------------------------
-
-        Shader make_fallback_shader()
+        for (uint32 i = 1U; i + 1U < polygon.size(); ++i)
         {
-            return Shader(
-                std::vector<ShaderSource> {
-                    ShaderSource(
-                        "#version 450 core\n"
-                        "layout(location = 0) in vec3 a_position;\n"
-                        "out vec3 v_color;\n"
-                        "void main()\n"
-                        "{\n"
-                        "    v_color = (a_position * 0.5) + vec3(0.5, 0.5, 0.75);\n"
-                        "    gl_Position = vec4(a_position, 1.0);\n"
-                        "}\n",
-                        ShaderType::VERTEX),
-                    ShaderSource(
-                        "#version 450 core\n"
-                        "layout(location = 0) out vec4 o_final_color;\n"
-                        "in vec3 v_color;\n"
-                        "void main()\n"
-                        "{\n"
-                        "    o_final_color = vec4(clamp(v_color, 0.15, 1.0), 1.0);\n"
-                        "}\n",
-                        ShaderType::FRAGMENT),
-                });
+            const uint32 base = static_cast<uint32>(geometry.vertices.size() / 3U);
+            append_projected_vertex(polygon[0U], geometry);
+            append_projected_vertex(polygon[i], geometry);
+            append_projected_vertex(polygon[i + 1U], geometry);
+            geometry.indices.push_back(base);
+            geometry.indices.push_back(base + 1U);
+            geometry.indices.push_back(base + 2U);
+        }
+    }
+
+    static uint32 get_vertex_stride_float_count(const Mesh& mesh)
+    {
+        const uint32 stride_bytes = mesh.vertices.layout.stride;
+        return stride_bytes == 0U ? 16U : stride_bytes / static_cast<uint32>(sizeof(float));
+    }
+
+    static bool can_render_mesh_directly(const Mesh& mesh)
+    {
+        constexpr uint32 model_pipeline_stride = 16U;
+        return !mesh.vertices.empty() && !mesh.indices.empty()
+               && get_vertex_stride_float_count(mesh) == model_pipeline_stride;
+    }
+
+    static void append_mesh_geometry(
+        const Mesh& mesh,
+        const Mat4& world_to_clip,
+        GeometryBuildResult& geometry)
+    {
+        if (mesh.vertices.empty() || mesh.indices.empty())
+            return;
+
+        const uint32 stride = get_vertex_stride_float_count(mesh);
+        if (stride < 3U)
+            return;
+
+        const uint32 source_vertex_count = static_cast<uint32>(mesh.vertices.size() / stride);
+        auto clip_positions = std::vector<Vec4> {};
+        clip_positions.reserve(source_vertex_count);
+
+        for (uint32 vertex_index = 0U; vertex_index < source_vertex_count; ++vertex_index)
+        {
+            const uint32 offset = vertex_index * stride;
+            const Vec4 local = Vec4(
+                mesh.vertices.vertices[offset],
+                mesh.vertices.vertices[offset + 1U],
+                mesh.vertices.vertices[offset + 2U],
+                1.0F);
+            clip_positions.push_back(world_to_clip * local);
         }
 
-        GraphicsPipelineDesc make_fallback_pipeline_desc()
+        for (uint32 index_offset = 0U; index_offset + 2U < mesh.indices.size(); index_offset += 3U)
         {
-            return GraphicsPipelineDesc {
-                .shader = make_fallback_shader(),
-                .vertex_buffers =
-                    {
-                        GraphicsVertexBufferLayoutDesc {
-                            .slot = 0U,
-                            .stride = static_cast<uint32>(sizeof(float) * 3U),
-                        },
+            const uint32 i0 = mesh.indices[index_offset];
+            const uint32 i1 = mesh.indices[index_offset + 1U];
+            const uint32 i2 = mesh.indices[index_offset + 2U];
+            if (i0 >= source_vertex_count || i1 >= source_vertex_count || i2 >= source_vertex_count)
+                continue;
+
+            append_clipped_triangle(
+                clip_positions[i0],
+                clip_positions[i1],
+                clip_positions[i2],
+                geometry);
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Fallback pipeline definition
+    // ---------------------------------------------------------------------------
+
+    static Shader make_opaque_fallback_shader()
+    {
+        return Shader(
+            std::vector<ShaderSource> {
+                ShaderSource(
+                    "#version 450 core\n"
+                    "layout(location = 0) in vec3 a_position;\n"
+                    "out vec3 v_color;\n"
+                    "void main()\n"
+                    "{\n"
+                    "    v_color = (a_position * 0.5) + vec3(0.5, 0.5, 0.75);\n"
+                    "    gl_Position = vec4(a_position, 1.0);\n"
+                    "}\n",
+                    ShaderType::VERTEX),
+                ShaderSource(
+                    "#version 450 core\n"
+                    "layout(location = 0) out vec4 o_final_color;\n"
+                    "in vec3 v_color;\n"
+                    "void main()\n"
+                    "{\n"
+                    "    o_final_color = vec4(clamp(v_color, 0.15, 1.0), 1.0);\n"
+                    "}\n",
+                    ShaderType::FRAGMENT),
+            });
+    }
+
+    static GraphicsPipelineDesc make_fallback_pipeline_desc()
+    {
+        return GraphicsPipelineDesc {
+            .shader = make_opaque_fallback_shader(),
+            .vertex_buffers =
+                {
+                    GraphicsVertexBufferLayoutDesc {
+                        .slot = 0U,
+                        .stride = static_cast<uint32>(sizeof(float) * 3U),
                     },
-                .vertex_attributes =
-                    {
-                        GraphicsVertexAttributeDesc {
-                            .location = 0U,
-                            .buffer_slot = 0U,
-                            .offset = 0U,
-                            .format = GraphicsVertexFormat::VEC3,
-                        },
+                },
+            .vertex_attributes =
+                {
+                    GraphicsVertexAttributeDesc {
+                        .location = 0U,
+                        .buffer_slot = 0U,
+                        .offset = 0U,
+                        .format = GraphicsVertexFormat::VEC3,
                     },
-                .primitive_type = GraphicsPrimitiveType::TRIANGLES,
-                .is_depth_test_enabled = true,
-                .is_depth_write_enabled = true,
-                .is_blending_enabled = false,
-                .is_culling_enabled = false,
-                .debug_name = "Toybox Fallback Geometry Pipeline",
-            };
-        }
-
-        uint64 make_mesh_cache_key(const std::shared_ptr<Mesh>& mesh_data)
-        {
-            return reinterpret_cast<uint64>(mesh_data.get());
-        }
-
-        uint64 make_dynamic_batch_key(const uint64 mesh_key, const uint64 material_key)
-        {
-            return hash_value(material_key, hash_value(mesh_key, 14695981039346656037ULL));
-        }
-
-        uint64 make_static_batch_key(
-            const Uuid vertex_buffer,
-            const Uuid index_buffer,
-            const uint32 index_count,
-            const uint64 material_key)
-        {
-            uint64 hash = hash_uuid(vertex_buffer, 14695981039346656037ULL);
-            hash = hash_uuid(index_buffer, hash);
-            hash = hash_value(index_count, hash);
-            hash = hash_value(material_key, hash);
-            return hash == 0U ? 1U : hash;
-        }
-
-        // ---------------------------------------------------------------------------
-        // Batch accumulation structures
-        // ---------------------------------------------------------------------------
-
-        struct DynamicBatch
-        {
-            std::shared_ptr<Mesh> mesh_data = {};
-            Uuid pipeline = {};
-            uint64 material_key = 0U;
-            Uuid material_uniform_buffer = {};
-            std::vector<GraphicsResourceBinding> textures = {};
-            std::vector<Mat4> transforms = {};
-        };
-
-        struct StaticBatch
-        {
-            Uuid vertex_buffer = {};
-            Uuid index_buffer = {};
-            uint32 index_count = 0U;
-            Uuid pipeline = {};
-            uint64 material_key = 0U;
-            Uuid material_uniform_buffer = {};
-            std::vector<GraphicsResourceBinding> textures = {};
-            std::vector<Mat4> transforms = {};
+                },
+            .primitive_type = GraphicsPrimitiveType::TRIANGLES,
+            .is_depth_test_enabled = true,
+            .is_depth_write_enabled = true,
+            .is_blending_enabled = false,
+            .is_culling_enabled = false,
+            .debug_name = "Toybox Fallback Geometry Pipeline",
         };
     }
+
+    static uint64 make_mesh_cache_key(const std::shared_ptr<Mesh>& mesh_data)
+    {
+        return reinterpret_cast<uint64>(mesh_data.get());
+    }
+
+    static uint64 make_dynamic_batch_key(const uint64 mesh_key, const uint64 material_key)
+    {
+        return hash_value(material_key, hash_value(mesh_key, 14695981039346656037ULL));
+    }
+
+    static uint64 make_static_batch_key(
+        const Uuid vertex_buffer,
+        const Uuid index_buffer,
+        const uint32 index_count,
+        const uint64 material_key)
+    {
+        uint64 hash = hash_uuid(vertex_buffer, 14695981039346656037ULL);
+        hash = hash_uuid(index_buffer, hash);
+        hash = hash_value(index_count, hash);
+        hash = hash_value(material_key, hash);
+        return hash == 0U ? 1U : hash;
+    }
+
+    // ---------------------------------------------------------------------------
+    // Batch accumulation structures
+    // ---------------------------------------------------------------------------
+
+    struct DynamicBatch
+    {
+        std::shared_ptr<Mesh> mesh_data = {};
+        Uuid pipeline = {};
+        uint64 material_key = 0U;
+        Uuid material_uniform_buffer = {};
+        std::vector<GraphicsResourceBinding> textures = {};
+        std::vector<Mat4> transforms = {};
+    };
+
+    struct StaticBatch
+    {
+        Uuid vertex_buffer = {};
+        Uuid index_buffer = {};
+        uint32 index_count = 0U;
+        Uuid pipeline = {};
+        uint64 material_key = 0U;
+        Uuid material_uniform_buffer = {};
+        std::vector<GraphicsResourceBinding> textures = {};
+        std::vector<Mat4> transforms = {};
+    };
 
     // ---------------------------------------------------------------------------
     // OpaqueSceneOperation implementation
@@ -963,13 +967,14 @@ namespace tbx
             !result)
             return result;
 
+        const auto executor = RenderCommandExecutor();
         for (const auto& draw : _draw_commands)
         {
             if (token && token.is_cancelled())
                 return backend.end_pass(),
                        Result(false, "OpaqueSceneOperation cancelled mid-pass.");
 
-            if (const auto result = execute_indexed_draw(backend, draw); !result)
+            if (const auto result = executor.execute_indexed_draw(backend, draw); !result)
                 return backend.end_pass(), result;
         }
 

--- a/engine/src/systems/graphics/pipeline/render_command_executor.cpp
+++ b/engine/src/systems/graphics/pipeline/render_command_executor.cpp
@@ -1,0 +1,95 @@
+#include "tbx/systems/graphics/pipeline/render_command_executor.h"
+
+namespace tbx
+{
+    Result RenderCommandExecutor::bind_common_resources(
+        IGraphicsBackend& backend,
+        const std::vector<GraphicsResourceBinding>& uniform_buffers,
+        const std::vector<GraphicsResourceBinding>& storage_buffers,
+        const std::vector<GraphicsResourceBinding>& textures,
+        const std::vector<GraphicsResourceBinding>& samplers) const
+    {
+        for (const auto& binding : uniform_buffers)
+        {
+            if (const auto result = backend.bind_uniform_buffer(binding.slot, binding.resource);
+                !result)
+                return result;
+        }
+
+        for (const auto& binding : storage_buffers)
+        {
+            if (const auto result = backend.bind_storage_buffer(binding.slot, binding.resource);
+                !result)
+                return result;
+        }
+
+        for (const auto& binding : textures)
+        {
+            if (const auto result = backend.bind_texture(binding.slot, binding.resource); !result)
+                return result;
+        }
+
+        for (const auto& binding : samplers)
+        {
+            if (const auto result = backend.bind_sampler(binding.slot, binding.resource); !result)
+                return result;
+        }
+
+        return {};
+    }
+
+    Result RenderCommandExecutor::bind_vertex_buffers(
+        IGraphicsBackend& backend,
+        const std::vector<GraphicsResourceBinding>& vertex_buffers) const
+    {
+        for (const auto& binding : vertex_buffers)
+        {
+            if (const auto result = backend.bind_vertex_buffer(binding.slot, binding.resource);
+                !result)
+                return result;
+        }
+
+        return {};
+    }
+
+    Result RenderCommandExecutor::execute_draw(
+        IGraphicsBackend& backend,
+        const GraphicsDrawCommand& command) const
+    {
+        if (const auto result = backend.bind_pipeline(command.pipeline); !result)
+            return result;
+        if (const auto result = bind_vertex_buffers(backend, command.vertex_buffers); !result)
+            return result;
+        if (const auto result = bind_common_resources(
+                backend,
+                command.uniform_buffers,
+                command.storage_buffers,
+                command.textures,
+                command.samplers);
+            !result)
+            return result;
+        return backend.draw(command.vertex_count, command.vertex_offset);
+    }
+
+    Result RenderCommandExecutor::execute_indexed_draw(
+        IGraphicsBackend& backend,
+        const GraphicsIndexedDrawCommand& command) const
+    {
+        if (const auto result = backend.bind_pipeline(command.pipeline); !result)
+            return result;
+        if (const auto result = bind_vertex_buffers(backend, command.vertex_buffers); !result)
+            return result;
+        if (const auto result = backend.bind_index_buffer(command.index_buffer, command.index_type);
+            !result)
+            return result;
+        if (const auto result = bind_common_resources(
+                backend,
+                command.uniform_buffers,
+                command.storage_buffers,
+                command.textures,
+                command.samplers);
+            !result)
+            return result;
+        return backend.draw_indexed(command.draw);
+    }
+}

--- a/engine/src/systems/graphics/pipeline/render_material_helpers.h
+++ b/engine/src/systems/graphics/pipeline/render_material_helpers.h
@@ -151,8 +151,7 @@ namespace tbx
                     !result)
                     return result;
             }
-            else if (const auto result =
-                         resource_manager.load_default_texture(texture_resource);
+            else if (const auto result = resource_manager.load_default_texture(texture_resource);
                      !result)
             {
                 return result;
@@ -201,50 +200,8 @@ namespace tbx
             return result;
 
         out.pipeline = material_resource.pipeline;
-        out.uniform_key =
-            make_material_key(out.pipeline, out.uniform_data, out.textures);
+        out.uniform_key = make_material_key(out.pipeline, out.uniform_data, out.textures);
         return {};
     }
 
-    // ---------------------------------------------------------------------------
-    // Indexed draw command execution — mirrors render_pass_operation.cpp logic
-    // ---------------------------------------------------------------------------
-
-    inline Result execute_indexed_draw(
-        IGraphicsBackend& backend,
-        const GraphicsIndexedDrawCommand& command)
-    {
-        if (const auto result = backend.bind_pipeline(command.pipeline); !result)
-            return result;
-        for (const auto& vb : command.vertex_buffers)
-        {
-            if (const auto result = backend.bind_vertex_buffer(vb.slot, vb.resource); !result)
-                return result;
-        }
-        if (const auto result =
-                backend.bind_index_buffer(command.index_buffer, command.index_type);
-            !result)
-            return result;
-        for (const auto& ub : command.uniform_buffers)
-        {
-            if (const auto result = backend.bind_uniform_buffer(ub.slot, ub.resource); !result)
-                return result;
-        }
-        for (const auto& sb : command.storage_buffers)
-        {
-            if (const auto result = backend.bind_storage_buffer(sb.slot, sb.resource); !result)
-                return result;
-        }
-        for (const auto& tex : command.textures)
-        {
-            if (const auto result = backend.bind_texture(tex.slot, tex.resource); !result)
-                return result;
-        }
-        for (const auto& samp : command.samplers)
-        {
-            if (const auto result = backend.bind_sampler(samp.slot, samp.resource); !result)
-                return result;
-        }
-        return backend.draw_indexed(command.draw);
-    }
 }

--- a/engine/src/systems/graphics/pipeline/render_pass_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/render_pass_operation.cpp
@@ -1,99 +1,11 @@
 #include "tbx/systems/graphics/pipeline/render_pass_operation.h"
+#include "tbx/systems/graphics/pipeline/render_command_executor.h"
 #include <any>
 #include <optional>
 #include <utility>
 
 namespace tbx
 {
-    static Result bind_common_resources(
-        IGraphicsBackend& backend,
-        const std::vector<GraphicsResourceBinding>& uniform_buffers,
-        const std::vector<GraphicsResourceBinding>& storage_buffers,
-        const std::vector<GraphicsResourceBinding>& textures,
-        const std::vector<GraphicsResourceBinding>& samplers)
-    {
-        for (const auto& binding : uniform_buffers)
-        {
-            if (const auto result = backend.bind_uniform_buffer(binding.slot, binding.resource);
-                !result)
-                return result;
-        }
-
-        for (const auto& binding : storage_buffers)
-        {
-            if (const auto result = backend.bind_storage_buffer(binding.slot, binding.resource);
-                !result)
-                return result;
-        }
-
-        for (const auto& binding : textures)
-        {
-            if (const auto result = backend.bind_texture(binding.slot, binding.resource); !result)
-                return result;
-        }
-
-        for (const auto& binding : samplers)
-        {
-            if (const auto result = backend.bind_sampler(binding.slot, binding.resource); !result)
-                return result;
-        }
-
-        return {};
-    }
-
-    static Result bind_vertex_buffers(
-        IGraphicsBackend& backend,
-        const std::vector<GraphicsResourceBinding>& vertex_buffers)
-    {
-        for (const auto& binding : vertex_buffers)
-        {
-            if (const auto result = backend.bind_vertex_buffer(binding.slot, binding.resource);
-                !result)
-                return result;
-        }
-
-        return {};
-    }
-
-    static Result execute_draw(IGraphicsBackend& backend, const GraphicsDrawCommand& command)
-    {
-        if (const auto result = backend.bind_pipeline(command.pipeline); !result)
-            return result;
-        if (const auto result = bind_vertex_buffers(backend, command.vertex_buffers); !result)
-            return result;
-        if (const auto result = bind_common_resources(
-                backend,
-                command.uniform_buffers,
-                command.storage_buffers,
-                command.textures,
-                command.samplers);
-            !result)
-            return result;
-        return backend.draw(command.vertex_count, command.vertex_offset);
-    }
-
-    static Result execute_draw(
-        IGraphicsBackend& backend,
-        const GraphicsIndexedDrawCommand& command)
-    {
-        if (const auto result = backend.bind_pipeline(command.pipeline); !result)
-            return result;
-        if (const auto result = bind_vertex_buffers(backend, command.vertex_buffers); !result)
-            return result;
-        if (const auto result = backend.bind_index_buffer(command.index_buffer, command.index_type);
-            !result)
-            return result;
-        if (const auto result = bind_common_resources(
-                backend,
-                command.uniform_buffers,
-                command.storage_buffers,
-                command.textures,
-                command.samplers);
-            !result)
-            return result;
-        return backend.draw_indexed(command.draw);
-    }
-
     static bool is_cancelled(const CancellationToken& cancellation_token)
     {
         return cancellation_token && cancellation_token.is_cancelled();
@@ -135,12 +47,13 @@ namespace tbx
         if (const auto result = backend.begin_pass(_pass.pass); !result)
             return result;
 
+        const auto executor = RenderCommandExecutor();
         for (const auto& draw : _pass.draws)
         {
             if (is_cancelled(cancellation_token))
                 return Result(false, "Graphics render pass operation cancelled.");
 
-            if (const auto result = execute_draw(backend, draw); !result)
+            if (const auto result = executor.execute_draw(backend, draw); !result)
                 return result;
         }
 
@@ -149,7 +62,7 @@ namespace tbx
             if (is_cancelled(cancellation_token))
                 return Result(false, "Graphics render pass operation cancelled.");
 
-            if (const auto result = execute_draw(backend, draw); !result)
+            if (const auto result = executor.execute_indexed_draw(backend, draw); !result)
                 return result;
         }
 

--- a/engine/src/systems/graphics/pipeline/render_pipeline_config.cpp
+++ b/engine/src/systems/graphics/pipeline/render_pipeline_config.cpp
@@ -1,0 +1,16 @@
+#include "tbx/systems/graphics/pipeline/render_pipeline_config.h"
+#include "tbx/systems/graphics/pipeline/opaque_scene_operation.h"
+#include "tbx/systems/graphics/pipeline/skybox_operation.h"
+#include "tbx/systems/graphics/pipeline/view_uniform_operation.h"
+
+namespace tbx
+{
+    RenderPipelineConfig RenderPipelineConfig::standard()
+    {
+        auto config = RenderPipelineConfig();
+        config.operations.push_back(std::make_unique<ViewUniformOperation>());
+        config.operations.push_back(std::make_unique<SkyboxOperation>());
+        config.operations.push_back(std::make_unique<OpaqueSceneOperation>());
+        return config;
+    }
+}

--- a/engine/src/systems/graphics/pipeline/skybox_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/skybox_operation.cpp
@@ -2,6 +2,7 @@
 #include "render_material_helpers.h"
 #include "tbx/systems/graphics/material.h"
 #include "tbx/systems/graphics/mesh.h"
+#include "tbx/systems/graphics/pipeline/render_command_executor.h"
 #include "tbx/systems/graphics/pipeline/render_frame_context.h"
 #include "tbx/systems/graphics/render_graph.h"
 #include "tbx/systems/math/matrices.h"
@@ -9,6 +10,14 @@
 
 namespace tbx
 {
+    RenderOperationDebugInfo SkyboxOperation::get_debug_info() const
+    {
+        auto debug_info = RenderOperationDebugInfo();
+        debug_info.debug_name = "Toybox Skybox Operation";
+        debug_info.category = "Scene Rendering";
+        return debug_info;
+    }
+
     Result SkyboxOperation::ensure_geometry(IGraphicsBackend& backend)
     {
         if (_vertex_buffer.is_valid() && _index_buffer.is_valid() && _index_count > 0U)
@@ -130,8 +139,7 @@ namespace tbx
         auto& resource_manager = context.resource_manager.get();
 
         auto resolved = ResolvedMaterial {};
-        if (const auto result = resolve_material(sky_material, resource_manager, resolved);
-            !result)
+        if (const auto result = resolve_material(sky_material, resource_manager, resolved); !result)
             return result;
 
         if (const auto result = ensure_material_uniform(
@@ -158,9 +166,7 @@ namespace tbx
         return {};
     }
 
-    Result SkyboxOperation::execute(
-        IGraphicsBackend& backend,
-        const CancellationToken& token)
+    Result SkyboxOperation::execute(IGraphicsBackend& backend, const CancellationToken& token)
     {
         if (!_ready)
             return {};
@@ -203,7 +209,8 @@ namespace tbx
                 },
         };
 
-        if (const auto result = execute_indexed_draw(backend, draw); !result)
+        const auto executor = RenderCommandExecutor();
+        if (const auto result = executor.execute_indexed_draw(backend, draw); !result)
             return backend.end_pass(), result;
 
         return backend.end_pass();

--- a/engine/src/systems/graphics/pipeline/view_uniform_operation.cpp
+++ b/engine/src/systems/graphics/pipeline/view_uniform_operation.cpp
@@ -5,13 +5,18 @@
 
 namespace tbx
 {
-    namespace
+    RenderOperationDebugInfo ViewUniformOperation::get_debug_info() const
     {
-        struct ViewUniformBlock
-        {
-            Mat4 view_projection = Mat4(1.0F);
-        };
+        auto debug_info = RenderOperationDebugInfo();
+        debug_info.debug_name = "Toybox View Uniform Operation";
+        debug_info.category = "Frame Setup";
+        return debug_info;
     }
+
+    struct ViewUniformBlock
+    {
+        Mat4 view_projection = Mat4(1.0F);
+    };
 
     Result ViewUniformOperation::prepare(RenderFrameContext& context)
     {

--- a/engine/src/systems/graphics/rendering.cpp
+++ b/engine/src/systems/graphics/rendering.cpp
@@ -2,10 +2,8 @@
 #include "tbx/systems/debugging/macros.h"
 #include "tbx/systems/ecs/entity.h"
 #include "tbx/systems/graphics/camera.h"
-#include "tbx/systems/graphics/pipeline/opaque_scene_operation.h"
 #include "tbx/systems/graphics/pipeline/render_frame_context.h"
-#include "tbx/systems/graphics/pipeline/skybox_operation.h"
-#include "tbx/systems/graphics/pipeline/view_uniform_operation.h"
+#include "tbx/systems/graphics/pipeline/render_pipeline_config.h"
 #include "tbx/systems/graphics/render_graph.h"
 #include "tbx/systems/math/matrices.h"
 #include <functional>
@@ -39,10 +37,9 @@ namespace tbx
                 found = true;
             });
 
-        const float aspect =
-            resolution.height == 0U
-                ? 1.0F
-                : static_cast<float>(resolution.width) / static_cast<float>(resolution.height);
+        const float aspect = resolution.height == 0U ? 1.0F
+                                                     : static_cast<float>(resolution.width)
+                                                           / static_cast<float>(resolution.height);
         view.camera.set_aspect(aspect);
         return view;
     }
@@ -63,9 +60,8 @@ namespace tbx
     {
         _initialization_result = backend.initialize(settings);
 
-        _operations.push_back(std::make_unique<ViewUniformOperation>());
-        _operations.push_back(std::make_unique<SkyboxOperation>());
-        _operations.push_back(std::make_unique<OpaqueSceneOperation>());
+        auto pipeline_config = RenderPipelineConfig::standard();
+        _operations = std::move(pipeline_config.operations);
     }
 
     Rendering::~Rendering() noexcept
@@ -128,6 +124,12 @@ namespace tbx
         {
             if (const auto result = operation->prepare(context); !result)
             {
+                const RenderOperationDebugInfo debug_info = operation->get_debug_info();
+                TBX_TRACE_WARNING(
+                    "Toybox render operation prepare failed [{} / {}]: {}",
+                    debug_info.category,
+                    debug_info.debug_name,
+                    result.get_report());
                 abort_frame(result);
                 return;
             }
@@ -139,6 +141,12 @@ namespace tbx
             if (const auto result = operation->execute(_backend.get(), CancellationToken {});
                 !result)
             {
+                const RenderOperationDebugInfo debug_info = operation->get_debug_info();
+                TBX_TRACE_WARNING(
+                    "Toybox render operation execute failed [{} / {}]: {}",
+                    debug_info.category,
+                    debug_info.debug_name,
+                    result.get_report());
                 abort_frame(result);
                 return;
             }


### PR DESCRIPTION
### Motivation
- Reduce duplication in draw/ bind logic and centralize command execution responsibilities. 
- Provide lightweight operation identity for better logging and diagnostics during prepare/execute failures. 
- Make pipeline composition configurable so the standard scene pipeline can be constructed in one place.

### Description
- Add `RenderCommandExecutor` (`render_command_executor.h/.cpp`) to centralize resource binding and draw/ indexed-draw execution and replace duplicate binding logic in `render_pass_operation.cpp`, `opaque_scene_operation.cpp`, and `skybox_operation.cpp` by calling `execute_draw` / `execute_indexed_draw`.
- Introduce `RenderOperationDebugInfo` and a pure virtual `IRenderOperation::get_debug_info()` along with implementations in `ViewUniformOperation`, `SkyboxOperation`, and `OpaqueSceneOperation` for category/name reporting.
- Add `RenderPipelineConfig` (`render_pipeline_config.h/.cpp`) with `RenderPipelineConfig::standard()` and switch `Rendering` to construct `_operations` from the config instead of manually pushing each operation.
- Refactor `opaque_scene_operation.cpp` helper functions and types (clipping/geometry build, pipeline creation, cache keys) into static scoped functions/types and tidy `render_material_helpers.h` by removing duplicated draw execution helpers.

### Testing
- Performed a full project build using the native build system (e.g. `cmake --build .`), which completed successfully.
- No unit test suite was executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbbe8ee35c8327bd38c37e2e1d7a88)