### PR TITLE
Gate polymorphic .meta type lookups with a polymorphic flag

### DIFF
--- a/engine/include/tbx/systems/assets/serialization_registry.h
+++ b/engine/include/tbx/systems/assets/serialization_registry.h
@@ -133,6 +133,7 @@ namespace tbx
     struct AssetLoadMetadata
     {
         Uuid id = {};
+        bool polymorphic = false;
         uint32 version = 0U;
     };
 

--- a/engine/src/systems/assets/serialization_registry.cpp
+++ b/engine/src/systems/assets/serialization_registry.cpp
@@ -68,11 +68,10 @@ namespace tbx
             return read;
         }
 
-        // Rename-hardened references resolve by UUID, but construction needs the registered C++
-        // asset type. A meta "type" field is preferred; the filename fallback preserves existing
-        // asset conventions for simple cases.
+        // Only polymorphic metas may use "type" as the registered C++ discriminator because
+        // legacy metas such as shaders already use that key for asset-specific settings.
         auto type_name = std::string();
-        if (meta_data.has_value())
+        if (metadata.polymorphic && meta_data.has_value())
         {
             auto meta_json = Json();
             if (JsonParser::try_parse(*meta_data, meta_json))
@@ -152,6 +151,8 @@ namespace tbx
                 out_metadata.id = Uuid(numeric_id);
             }
         }
+
+        static_cast<void>(JsonParser::try_get(data, "polymorphic", out_metadata.polymorphic));
 
         auto version = uint32();
         if (!JsonParser::try_get(data, "version", version))

--- a/engine/tests/assets/asset_manager_tests.cpp
+++ b/engine/tests/assets/asset_manager_tests.cpp
@@ -66,6 +66,14 @@ namespace tbx
         int value = 0;
     };
 
+    struct NonPolymorphicMetaAsset : Asset
+    {
+    };
+
+    struct PolymorphicMetaAsset : Asset
+    {
+    };
+
     template <>
     struct Serializer<CustomBodyAsset>
     {
@@ -276,6 +284,22 @@ namespace tbx
         asset.loader_observed_default = asset.value == 7;
         asset.value = 11;
         return {};
+    }
+
+    template <typename TAsset>
+    static void register_named_asset_type(std::string type_name)
+    {
+        register_asset_type_entry(
+            AssetTypeRegistration {
+                .type_name = std::move(type_name),
+                .type = std::type_index(typeid(TAsset)),
+                .version = 1U,
+                .create_asset =
+                    []
+                {
+                    return std::make_unique<TAsset>();
+                },
+            });
     }
 
     class NullMessageDispatcher final : public IMessageDispatcher
@@ -538,6 +562,50 @@ namespace tbx::tests::assets
         EXPECT_EQ(asset->id, Uuid(0x2AU));
         EXPECT_EQ(asset->version, 1U);
         EXPECT_EQ(asset->value, 42);
+    }
+
+    TEST(serialization_registry, registered_asset_ignores_type_key_without_polymorphic_flag)
+    {
+        // Arrange
+        unregister_asset_type_entry(std::type_index(typeid(NonPolymorphicMetaAsset)));
+        register_named_asset_type<NonPolymorphicMetaAsset>("non_polymorphic_meta_asset");
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text(
+            "content/non_polymorphic_meta_asset.asset.meta",
+            R"({ "id": { "value": 52 }, "version": 1, "type": "fragment" })");
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        auto read =
+            registry.read_registered_asset_result("content/non_polymorphic_meta_asset.asset");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded()) << read.result.get_report();
+        EXPECT_NE(std::dynamic_pointer_cast<NonPolymorphicMetaAsset>(read.asset), nullptr);
+        EXPECT_EQ(read.metadata.id, Uuid(0x34U));
+        EXPECT_FALSE(read.metadata.polymorphic);
+    }
+
+    TEST(serialization_registry, registered_asset_uses_type_key_when_polymorphic_flag_is_set)
+    {
+        // Arrange
+        unregister_asset_type_entry(std::type_index(typeid(PolymorphicMetaAsset)));
+        register_named_asset_type<PolymorphicMetaAsset>("polymorphic_meta_asset");
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text(
+            "content/renamed.asset.meta",
+            "{ \"id\": { \"value\": 53 }, \"version\": 1, "
+            "\"polymorphic\": true, \"type\": \"polymorphic_meta_asset\" }");
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        auto read = registry.read_registered_asset_result("content/renamed.asset");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded()) << read.result.get_report();
+        EXPECT_NE(std::dynamic_pointer_cast<PolymorphicMetaAsset>(read.asset), nullptr);
+        EXPECT_EQ(read.metadata.id, Uuid(0x35U));
+        EXPECT_TRUE(read.metadata.polymorphic);
     }
 
     TEST(serialization_registry, asset_meta_rejects_missing_version)

--- a/engine/tests/scripting/script_system_tests.cpp
+++ b/engine/tests/scripting/script_system_tests.cpp
@@ -192,7 +192,8 @@ namespace tbx::tests::scripting
             })");
         file_ops->set_text(
             "Scripts/Door.script.meta",
-            R"({ "id": { "value": 1090519041 }, "version": 1, "type": "door_controller" })");
+            "{ \"id\": { \"value\": 1090519041 }, \"version\": 1, "
+            "\"polymorphic\": true, \"type\": \"door_controller\" }");
         file_ops->set_text("Scripts/Door.script", R"({ "open_speed": 2.0 })");
 
         auto dispatcher = std::make_shared<NullMessageDispatcher>();

--- a/examples/3d_example/assets/Scripts/FlashlightController.script.meta
+++ b/examples/3d_example/assets/Scripts/FlashlightController.script.meta
@@ -1,5 +1,6 @@
 ﻿{
     "id": 822100003,
     "version": 1,
+    "polymorphic": true,
     "type": "FlashlightController"
 }

--- a/examples/3d_example/assets/Scripts/PlayerController.script.meta
+++ b/examples/3d_example/assets/Scripts/PlayerController.script.meta
@@ -1,5 +1,6 @@
 ﻿{
     "id": 822100001,
     "version": 1,
+    "polymorphic": true,
     "type": "PlayerController"
 }

--- a/examples/3d_example/assets/Scripts/SkyRotator.script.meta
+++ b/examples/3d_example/assets/Scripts/SkyRotator.script.meta
@@ -1,5 +1,6 @@
 ﻿{
     "id": 822100002,
     "version": 1,
+    "polymorphic": true,
     "type": "SkyRotator"
 }

--- a/examples/3d_example/assets/Scripts/SunRotator.script.meta
+++ b/examples/3d_example/assets/Scripts/SunRotator.script.meta
@@ -1,5 +1,6 @@
 ﻿{
     "id": 822100005,
     "version": 1,
+    "polymorphic": true,
     "type": "SunRotator"
 }


### PR DESCRIPTION
### Motivation
- Prevent non-polymorphic `.meta` files (e.g. shader stage metadata like `"type": "fragment"`) from being interpreted as the registered C++ asset type and causing incorrect lookups and load failures. 
- Make it explicit which sidecar metas are polymorphic so polymorphic assets (scripts, etc.) can still use `"type"` as the asset-discriminator safely.

### Description
- Add a `polymorphic` boolean to `AssetLoadMetadata` and populate it when reading `.meta` files. 
- Only parse/consume the `.meta` `"type"` field as the registered C++ asset discriminator when `metadata.polymorphic` is true; otherwise fall back to the filename-based type name. 
- Mark example script `.meta` files and one scripting test `.meta` as `"polymorphic": true` so script assets continue to resolve by registered type name. 
- Add unit-test coverage to verify that non-polymorphic metas ignore `"type"` and polymorphic metas use `"type"` to select the registered asset type.

### Testing
- Ran `git diff --check` which passed. 
- Configured with `cmake --preset clang-sanitize-tests` which completed successfully. 
- Attempted `cmake --build --preset clang-sanitize-debug-tests` which failed during third-party SDL linking with ASan/UBSan runtime symbol link errors before full validation could complete. 
- Configured and built test targets with `cmake --preset clang-tests` and attempted several `cmake --build --preset clang-debug-tests` targets; incremental compilation of test translation units (generated `asset_manager_tests.generated.cpp.o` and `script_system_tests.cpp.o`) completed, but full test-suite/link steps failed earlier in the tree due to unrelated third-party/linker and engine compile issues. 
- Ran `clang-format` locally which was rejected due to the repository `.clang-format` containing an unsupported key in this environment (`OneLineFormatOffRegex`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2701e8ac83278a8bab85aa138054)