### PR TITLE
Defer async reload swap and restrict polymorphic .meta type lookup

### DIFF
--- a/engine/include/tbx/systems/assets/manager.inl
+++ b/engine/include/tbx/systems/assets/manager.inl
@@ -36,6 +36,7 @@ namespace tbx
         std::chrono::steady_clock::time_point last_access = {};
         Uuid asset_id = {};
         std::shared_future<Result> pending_load = {};
+        std::shared_ptr<TAsset> pending_reload_asset = {};
         AssetLoadParameters<TAsset> load_parameters = {};
         bool has_load_parameters = false;
         uint64 revision = 0U;
@@ -73,7 +74,16 @@ namespace tbx
                                                          : AssetLoadParameters<TAsset> {};
             auto promise =
                 serialization_registry.read_async<TAsset>(entry.resolved_path, parameters);
-            auto result = Result(promise.asset != nullptr, "Asset reload failed.");
+            auto result = Result(promise.asset != nullptr, promise.asset ? "" : "Asset reload failed.");
+            if (!result.succeeded())
+            {
+                return {
+                    .attempted = true,
+                    .result = result,
+                    .revision = record.revision,
+                };
+            }
+
             if (promise.promise.valid()
                 && promise.promise.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
             {
@@ -84,34 +94,38 @@ namespace tbx
                         false,
                         read_result.get_report().empty() ? std::string("Asset reload failed.")
                                                          : read_result.get_report());
+                    return {
+                        .attempted = true,
+                        .result = result,
+                        .revision = record.revision,
+                    };
                 }
-                else if (promise.asset)
-                {
-                    result = Result(true, read_result.get_report());
-                }
-            }
-            // Keep the existing record intact when a hot reload fails.
-            if (!result.succeeded())
-            {
+
+                populate_loaded_asset_data<TAsset>(promise.asset);
+                promise.asset->id = entry.asset_id;
+                record.asset = std::move(promise.asset);
+                record.pending_load = {};
+                record.pending_reload_asset = {};
+                record.load_parameters = parameters;
+                record.has_load_parameters = true;
+                record.stream_state = AssetStreamState::LOADED;
+                record.last_access = timestamp;
+                record.revision += 1U;
+
                 return {
                     .attempted = true,
-                    .result = result,
+                    .result = Result(true, read_result.get_report()),
                     .revision = record.revision,
                 };
             }
 
-            populate_loaded_asset_data<TAsset>(promise.asset);
-            if (promise.asset)
-                promise.asset->id = entry.asset_id;
-            record.asset = std::move(promise.asset);
+            // The current asset stays visible until async reload proves the replacement is valid.
             record.pending_load = promise.promise;
+            record.pending_reload_asset = std::move(promise.asset);
             record.load_parameters = parameters;
             record.has_load_parameters = true;
-            record.stream_state =
-                record.asset ? AssetStreamState::LOADING : AssetStreamState::UNLOADED;
+            record.stream_state = AssetStreamState::LOADING;
             record.last_access = timestamp;
-            update_asset_stream_state(record);
-            record.revision += 1U;
 
             return {
                 .attempted = true,
@@ -136,6 +150,8 @@ namespace tbx
                     continue;
 
                 record.asset.reset();
+                record.pending_reload_asset.reset();
+                record.pending_load = {};
                 record.stream_state = AssetStreamState::UNLOADED;
                 unloaded_count += 1U;
             }
@@ -219,9 +235,30 @@ namespace tbx
         using namespace std::chrono_literals;
         if (record.pending_load.wait_for(0s) == std::future_status::ready)
         {
+            const Result load_result = record.pending_load.get();
+            record.pending_load = {};
+
+            if (record.pending_reload_asset)
+            {
+                if (load_result.succeeded())
+                {
+                    populate_loaded_asset_data<TAsset>(record.pending_reload_asset);
+                    record.pending_reload_asset->id = record.asset_id;
+                    record.asset = std::move(record.pending_reload_asset);
+                    record.revision += 1U;
+                }
+                else
+                {
+                    record.pending_reload_asset.reset();
+                }
+            }
+            else if (!load_result.succeeded())
+            {
+                record.asset.reset();
+            }
+
             record.stream_state =
                 record.asset ? AssetStreamState::LOADED : AssetStreamState::UNLOADED;
-            record.pending_load = {};
         }
     }
 
@@ -593,6 +630,8 @@ namespace tbx
             asset_record.asset_id,
             typeid(TAsset).name());
         asset_record.asset.reset();
+        asset_record.pending_reload_asset.reset();
+        asset_record.pending_load = {};
         asset_record.stream_state = AssetStreamState::UNLOADED;
         return true;
     }

--- a/engine/include/tbx/systems/physics/physics.h
+++ b/engine/include/tbx/systems/physics/physics.h
@@ -5,28 +5,11 @@
 #include "tbx/systems/ecs/world/manager.h"
 #include "tbx/systems/physics/settings.h"
 #include "tbx/types/assets/world.h"
-#include "tbx/types/quaternions.h"
 #include "tbx/types/raycast.h"
+#include <memory>
 
 namespace tbx
 {
-    /// @brief
-    /// Purpose: Tracks backend physics resources and transform state for one ECS entity.
-    /// @details
-    /// Ownership: Stores non-owning backend handles; Physics owns record lifetime.
-    /// Thread Safety: Not thread-safe; owned by the main-thread Physics service.
-    struct PhysicsEntityRecord
-    {
-        PhysicsColliderHandle collider = {};
-        PhysicsRigidbodyHandle rigidbody = {};
-        Vec3 last_position = Vec3(0.0F, 0.0F, 0.0F);
-        Quat last_rotation = Quat(1.0F, 0.0F, 0.0F, 0.0F);
-        Vec3 last_scale = Vec3(1.0F, 1.0F, 1.0F);
-        bool has_last_transform = false;
-        bool is_physics_driven = false;
-        bool is_trigger_only = false;
-    };
-
     /// @brief
     /// Purpose: Application-owned physics service that synchronizes ECS components with the
     /// registered physics backend.
@@ -69,14 +52,21 @@ namespace tbx
         void on_asset_reload(const AssetReloadContext& context);
 
       private:
-        void destroy_record(PhysicsEntityRecord& record);
+        struct EntityRecord;
+        struct EntityRecordDeleter
+        {
+            void operator()(EntityRecord* record) const noexcept;
+        };
+        using EntityRecordPtr = std::unique_ptr<EntityRecord, EntityRecordDeleter>;
+
+        void destroy_record(EntityRecord& record);
 
       private:
         std::weak_ptr<IPhysicsBackend> _backend = {};
         std::weak_ptr<AssetManager> _asset_manager = {};
         std::weak_ptr<AssetReloadQueue> _reload_queue = {};
         std::weak_ptr<WorldManager> _world_manager = {};
-        std::unordered_map<Uuid, PhysicsEntityRecord> _records_by_entity = {};
+        std::unordered_map<Uuid, EntityRecordPtr> _records_by_entity = {};
         std::unordered_map<uint64, Uuid> _entity_by_rigidbody_handle = {};
         std::unordered_map<Uuid, std::unordered_set<Uuid>> _overlap_entities_by_trigger = {};
         std::unordered_set<Uuid> _pending_model_reloads = {};

--- a/engine/include/tbx/systems/physics/physics.h
+++ b/engine/include/tbx/systems/physics/physics.h
@@ -5,10 +5,28 @@
 #include "tbx/systems/ecs/world/manager.h"
 #include "tbx/systems/physics/settings.h"
 #include "tbx/types/assets/world.h"
+#include "tbx/types/quaternions.h"
 #include "tbx/types/raycast.h"
 
 namespace tbx
 {
+    /// @brief
+    /// Purpose: Tracks backend physics resources and transform state for one ECS entity.
+    /// @details
+    /// Ownership: Stores non-owning backend handles; Physics owns record lifetime.
+    /// Thread Safety: Not thread-safe; owned by the main-thread Physics service.
+    struct PhysicsEntityRecord
+    {
+        PhysicsColliderHandle collider = {};
+        PhysicsRigidbodyHandle rigidbody = {};
+        Vec3 last_position = Vec3(0.0F, 0.0F, 0.0F);
+        Quat last_rotation = Quat(1.0F, 0.0F, 0.0F, 0.0F);
+        Vec3 last_scale = Vec3(1.0F, 1.0F, 1.0F);
+        bool has_last_transform = false;
+        bool is_physics_driven = false;
+        bool is_trigger_only = false;
+    };
+
     /// @brief
     /// Purpose: Application-owned physics service that synchronizes ECS components with the
     /// registered physics backend.
@@ -51,15 +69,14 @@ namespace tbx
         void on_asset_reload(const AssetReloadContext& context);
 
       private:
-        struct EntityRecord;
-        void destroy_record(EntityRecord& record);
+        void destroy_record(PhysicsEntityRecord& record);
 
       private:
         std::weak_ptr<IPhysicsBackend> _backend = {};
         std::weak_ptr<AssetManager> _asset_manager = {};
         std::weak_ptr<AssetReloadQueue> _reload_queue = {};
         std::weak_ptr<WorldManager> _world_manager = {};
-        std::unordered_map<Uuid, EntityRecord> _records_by_entity = {};
+        std::unordered_map<Uuid, PhysicsEntityRecord> _records_by_entity = {};
         std::unordered_map<uint64, Uuid> _entity_by_rigidbody_handle = {};
         std::unordered_map<Uuid, std::unordered_set<Uuid>> _overlap_entities_by_trigger = {};
         std::unordered_set<Uuid> _pending_model_reloads = {};

--- a/engine/src/systems/assets/serialization_registry.cpp
+++ b/engine/src/systems/assets/serialization_registry.cpp
@@ -69,14 +69,19 @@ namespace tbx
         }
 
         // Rename-hardened references resolve by UUID, but construction needs the registered C++
-        // asset type. A meta "type" field is preferred; the filename fallback preserves existing
-        // asset conventions for simple cases.
+        // asset type. Only explicitly polymorphic meta files use "type" as that discriminator so
+        // asset-specific metadata, such as shader stages, can keep their existing key names.
         auto type_name = std::string();
         if (meta_data.has_value())
         {
             auto meta_json = Json();
-            if (JsonParser::try_parse(*meta_data, meta_json))
+            auto is_polymorphic = false;
+            if (JsonParser::try_parse(*meta_data, meta_json)
+                && JsonParser::try_get(meta_json, "polymorphic", is_polymorphic)
+                && is_polymorphic)
+            {
                 static_cast<void>(JsonParser::try_get(meta_json, "type", type_name));
+            }
         }
         if (type_name.empty())
             type_name = make_serializable_type_name(asset_path.stem().string());

--- a/engine/src/systems/physics/physics.cpp
+++ b/engine/src/systems/physics/physics.cpp
@@ -409,6 +409,23 @@ namespace tbx
         return create_info;
     }
 
+    struct Physics::EntityRecord
+    {
+        PhysicsColliderHandle collider = {};
+        PhysicsRigidbodyHandle rigidbody = {};
+        Vec3 last_position = Vec3(0.0F, 0.0F, 0.0F);
+        Quat last_rotation = Quat(1.0F, 0.0F, 0.0F, 0.0F);
+        Vec3 last_scale = Vec3(1.0F, 1.0F, 1.0F);
+        bool has_last_transform = false;
+        bool is_physics_driven = false;
+        bool is_trigger_only = false;
+    };
+
+    void Physics::EntityRecordDeleter::operator()(EntityRecord* record) const noexcept
+    {
+        delete record;
+    }
+
     Physics::Physics(
         std::weak_ptr<IPhysicsBackend> backend,
         std::weak_ptr<AssetManager> asset_manager,
@@ -468,7 +485,7 @@ namespace tbx
         {
             if (const auto record_it = _records_by_entity.find(raycast_query.ignored_entity_id);
                 record_it != _records_by_entity.end())
-                ignored_rigidbody = record_it->second.rigidbody;
+                ignored_rigidbody = record_it->second->rigidbody;
         }
 
         auto backend_hit = PhysicsRaycastHit {};
@@ -526,14 +543,14 @@ namespace tbx
     void Physics::clear_resources()
     {
         for (auto& record_entry : _records_by_entity)
-            destroy_record(record_entry.second);
+            destroy_record(*record_entry.second);
 
         _records_by_entity.clear();
         _entity_by_rigidbody_handle.clear();
         _overlap_entities_by_trigger.clear();
     }
 
-    void Physics::destroy_record(PhysicsEntityRecord& record)
+    void Physics::destroy_record(EntityRecord& record)
     {
         if (auto backend = _backend.lock())
         {
@@ -600,7 +617,7 @@ namespace tbx
             {
                 auto overlapped_rigidbodies = std::vector<PhysicsRigidbodyHandle> {};
                 backend->get_rigidbody_overlaps(
-                    record_it->second.rigidbody,
+                    record_it->second->rigidbody,
                     overlapped_rigidbodies);
                 current_overlaps.reserve(overlapped_rigidbodies.size());
                 for (const PhysicsRigidbodyHandle overlapped_rigidbody : overlapped_rigidbodies)
@@ -701,15 +718,15 @@ namespace tbx
 
             auto record_it = _records_by_entity.find(entity_id);
             if (record_it != _records_by_entity.end()
-                && (record_it->second.is_physics_driven != is_physics_driven
-                    || record_it->second.is_trigger_only != is_trigger_only
+                && (record_it->second->is_physics_driven != is_physics_driven
+                    || record_it->second->is_trigger_only != is_trigger_only
                     || (entity.has_component<StaticMesh>()
                         && _pending_model_reloads.contains(
                             entity.get_component<StaticMesh>().handle.id))
-                    || (entity.has_component<MeshCollider>() && record_it->second.has_last_transform
-                        && has_scale_changed(world_transform.scale, record_it->second.last_scale))))
+                    || (entity.has_component<MeshCollider>() && record_it->second->has_last_transform
+                        && has_scale_changed(world_transform.scale, record_it->second->last_scale))))
             {
-                destroy_record(record_it->second);
+                destroy_record(*record_it->second);
                 _records_by_entity.erase(record_it);
                 record_it = _records_by_entity.end();
             }
@@ -739,7 +756,8 @@ namespace tbx
                     continue;
                 }
 
-                auto& record = _records_by_entity[entity_id];
+                auto record_ptr = EntityRecordPtr(new EntityRecord());
+                auto& record = *record_ptr;
                 record.collider = collider;
                 record.rigidbody = rigidbody_handle;
                 record.last_position = world_transform.position;
@@ -748,11 +766,12 @@ namespace tbx
                 record.has_last_transform = true;
                 record.is_physics_driven = is_physics_driven;
                 record.is_trigger_only = is_trigger_only;
+                _records_by_entity[entity_id] = std::move(record_ptr);
                 _entity_by_rigidbody_handle[rigidbody_handle.value] = entity_id;
                 continue;
             }
 
-            auto& record = record_it->second;
+            auto& record = *record_it->second;
             const bool transform_is_dirty = record.has_last_transform
                                             && has_transform_changed(
                                                 world_transform,
@@ -813,7 +832,7 @@ namespace tbx
             if (record_it == _records_by_entity.end())
                 continue;
 
-            destroy_record(record_it->second);
+            destroy_record(*record_it->second);
             _records_by_entity.erase(record_it);
         }
     }
@@ -827,7 +846,7 @@ namespace tbx
         for (auto& record_entry : _records_by_entity)
         {
             const Uuid& entity_id = record_entry.first;
-            auto& record = record_entry.second;
+            auto& record = *record_entry.second;
 
             if (!world.has<Transform>(entity_id))
                 continue;

--- a/engine/src/systems/physics/physics.cpp
+++ b/engine/src/systems/physics/physics.cpp
@@ -409,18 +409,6 @@ namespace tbx
         return create_info;
     }
 
-    struct Physics::EntityRecord
-    {
-        PhysicsColliderHandle collider = {};
-        PhysicsRigidbodyHandle rigidbody = {};
-        Vec3 last_position = Vec3(0.0F, 0.0F, 0.0F);
-        Quat last_rotation = Quat(1.0F, 0.0F, 0.0F, 0.0F);
-        Vec3 last_scale = Vec3(1.0F, 1.0F, 1.0F);
-        bool has_last_transform = false;
-        bool is_physics_driven = false;
-        bool is_trigger_only = false;
-    };
-
     Physics::Physics(
         std::weak_ptr<IPhysicsBackend> backend,
         std::weak_ptr<AssetManager> asset_manager,
@@ -545,7 +533,7 @@ namespace tbx
         _overlap_entities_by_trigger.clear();
     }
 
-    void Physics::destroy_record(EntityRecord& record)
+    void Physics::destroy_record(PhysicsEntityRecord& record)
     {
         if (auto backend = _backend.lock())
         {

--- a/engine/tests/assets/asset_manager_tests.cpp
+++ b/engine/tests/assets/asset_manager_tests.cpp
@@ -22,6 +22,10 @@ namespace tbx
         std::filesystem::path resolved_include_path = {};
     };
 
+    struct PolymorphicFallbackAsset : Asset
+    {
+    };
+
     struct [[serializable]] [[version(1U)]] MacroOnlyAsset : Asset
     {
         [[prop]]
@@ -676,6 +680,63 @@ namespace tbx::tests::assets
         EXPECT_EQ(written_value, 77);
     }
 
+
+    TEST(serialization_registry, polymorphic_meta_type_selects_registered_asset_type_when_flagged)
+    {
+        // Arrange
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text("content/not_matching.custom", R"({ "label": "source", "value": 42 })");
+        file_ops->set_text(
+            "content/not_matching.custom.meta",
+            R"({ "id": { "value": 50 }, "version": 1, "polymorphic": true, "type": "CustomBodyAsset" })");
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        const auto read = registry.read_registered_asset_result("content/not_matching.custom");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded());
+        ASSERT_NE(read.asset, nullptr);
+        const auto asset = std::dynamic_pointer_cast<CustomBodyAsset>(read.asset);
+        ASSERT_NE(asset, nullptr);
+        EXPECT_EQ(asset->id, Uuid(0x32U));
+        EXPECT_EQ(asset->version, 1U);
+        EXPECT_EQ(asset->label, "source");
+        EXPECT_EQ(asset->value, 42);
+    }
+
+    TEST(serialization_registry, non_polymorphic_meta_ignores_asset_specific_type_field)
+    {
+        // Arrange
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text("content/StageNamedAsset.asset", "");
+        file_ops->set_text(
+            "content/StageNamedAsset.asset.meta",
+            R"({ "id": { "value": 51 }, "version": 1, "type": "fragment" })");
+        register_asset_type_entry(
+            AssetTypeRegistration {
+                .type_name = "stage_named_asset",
+                .type = std::type_index(typeid(PolymorphicFallbackAsset)),
+                .version = 1U,
+                .create_asset = []()
+                {
+                    return std::make_unique<PolymorphicFallbackAsset>();
+                },
+            });
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        const auto read = registry.read_registered_asset_result("content/StageNamedAsset.asset");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded());
+        ASSERT_NE(read.asset, nullptr);
+        const auto asset = std::dynamic_pointer_cast<PolymorphicFallbackAsset>(read.asset);
+        ASSERT_NE(asset, nullptr);
+        EXPECT_EQ(asset->id, Uuid(0x33U));
+        EXPECT_EQ(asset->version, 1U);
+    }
+
     TEST(serialization_registry, registered_loader_and_writer_override_custom_asset_defaults)
     {
         // Arrange
@@ -977,6 +1038,72 @@ namespace tbx::tests::assets
         AssetUsage usage = manager.get_usage<TestAsset>(handle);
         EXPECT_EQ(usage.stream_state, AssetStreamState::LOADED);
         EXPECT_EQ(streamed_in.asset->value, 99);
+    }
+
+
+    TEST(asset_manager, async_reload_swaps_asset_after_success)
+    {
+        // Arrange
+        std::filesystem::path working_directory = "/virtual/asset_manager";
+        AssetManager manager = make_manager(working_directory);
+        Handle handle("async_reload_success.asset");
+        TestAssetLoadParameters parameters = {.value = 5};
+        reset_test_asset_loader_state();
+        auto original_asset = manager.load<TestAsset>(handle, parameters);
+        ASSERT_NE(original_asset, nullptr);
+        const auto before_usage = manager.get_usage<TestAsset>(handle);
+
+        // Act
+        auto& loader_state = get_test_asset_loader_state();
+        loader_state.use_async = true;
+        const bool started_reload = manager.reload<TestAsset>(handle);
+        ASSERT_TRUE(started_reload);
+        ASSERT_NE(loader_state.asset, nullptr);
+        loader_state.asset->value = 99;
+        auto success = Result();
+        success.flag_success();
+        loader_state.completion->set_value(success);
+        const auto loading_usage = manager.get_usage<TestAsset>(handle);
+        auto reloaded_asset = manager.load<TestAsset>(handle, parameters);
+
+        // Assert
+        ASSERT_NE(reloaded_asset, nullptr);
+        EXPECT_NE(reloaded_asset, original_asset);
+        EXPECT_EQ(reloaded_asset->value, 99);
+        EXPECT_EQ(loading_usage.stream_state, AssetStreamState::LOADED);
+        EXPECT_EQ(loading_usage.revision, before_usage.revision + 1U);
+    }
+
+    TEST(asset_manager, async_reload_failure_preserves_existing_asset)
+    {
+        // Arrange
+        std::filesystem::path working_directory = "/virtual/asset_manager";
+        AssetManager manager = make_manager(working_directory);
+        Handle handle("async_reload_failure.asset");
+        TestAssetLoadParameters parameters = {.value = 7};
+        reset_test_asset_loader_state();
+        auto original_asset = manager.load<TestAsset>(handle, parameters);
+        ASSERT_NE(original_asset, nullptr);
+        const auto before_usage = manager.get_usage<TestAsset>(handle);
+
+        // Act
+        auto& loader_state = get_test_asset_loader_state();
+        loader_state.use_async = true;
+        const bool started_reload = manager.reload<TestAsset>(handle);
+        ASSERT_TRUE(started_reload);
+        ASSERT_NE(loader_state.asset, nullptr);
+        loader_state.asset->value = 99;
+        auto failure = Result();
+        failure.flag_failure("reload failed");
+        loader_state.completion->set_value(failure);
+        const auto after_usage = manager.get_usage<TestAsset>(handle);
+        auto loaded_asset = manager.load<TestAsset>(handle, parameters);
+
+        // Assert
+        EXPECT_EQ(loaded_asset, original_asset);
+        EXPECT_EQ(loaded_asset->value, 7);
+        EXPECT_EQ(after_usage.stream_state, AssetStreamState::LOADED);
+        EXPECT_EQ(after_usage.revision, before_usage.revision);
     }
 
     TEST(asset_manager, unloads_unreferenced_assets)


### PR DESCRIPTION
### Motivation
- Prevent hot-reload from overwriting the live asset when an async loader returns a non-ready/failed future by deferring the replacement until the future actually succeeds.
- Avoid misinterpreting asset-specific `.meta` fields (e.g., shader stage `"type": "fragment"`) as the registered C++ asset discriminator.
- Fix a compilation fragility caused by a forward-declared nested record type used inside an STL container so the Engine target builds cleanly with the toolchain.

### Description
- AssetManager: add `pending_reload_asset` to `Record<TAsset>`, keep the current `asset` visible while an async reload is pending, and only swap in `pending_reload_asset` and bump `revision` when the load future completes successfully; discard `pending_reload_asset` on failure and avoid premature revision bumps (changes in `manager.inl`).
- SerializationRegistry: treat the `.meta` `"type"` key as an asset-type discriminator only when the meta explicitly contains `"polymorphic": true`, otherwise fall back to the filename-based type name to preserve existing non-polymorphic metadata (changes in `serialization_registry.cpp`).
- Tests: add regression tests exercising polymorphic vs non-polymorphic meta behavior and async reload behavior (success and failure) under `engine/tests/assets/asset_manager_tests.cpp`.
- Physics: relocate the per-entity record into a concrete `PhysicsEntityRecord` definition (header) and update uses/signature (`destroy_record`) so the `_records_by_entity` map stores a complete value type and compiles cleanly (changes in `physics.h`/`physics.cpp`).

### Testing
- Ran the CI-local workflows and unit builds: `cmake --preset clang-tests` and `cmake --build --preset clang-debug-tests --target Engine` (Engine target built after the physics record fix) and `cmake --build --preset clang-debug-tests --target TbxAssetsTests`; these succeeded.
- Executed the assets unit test binary with the focused filter and ran preset ctest runs: `./build/clang-tests/testbin/Debug/TbxAssetsTests --gtest_filter=...` and `ctest --preset test-clang-debug -R TbxAssetsTests` as well as sanitizer builds `cmake --preset clang-sanitize-tests` + `ctest --preset test-clang-sanitize-debug -R TbxAssetsTests`; all exercised tests passed.
- Note: attempted `clang-format -i` but the repo `.clang-format` contains a key not recognized by the local toolchain (`OneLineFormatOffRegex`), so formatting was left as-is; `git diff --check` reported no outstanding whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2717e0a0832785ba6fc6259895dc)