### PR TITLE
Handle async asset hot-reloads, dispatch reload events, support polymorphic meta type, and refactor Physics record ownership

### DIFF
--- a/engine/include/tbx/systems/assets/manager.h
+++ b/engine/include/tbx/systems/assets/manager.h
@@ -243,6 +243,7 @@ namespace tbx
         struct IStore;
 
       private:
+        void dispatch_reload_events(const std::vector<StoreReloadResult>& reload_results) const;
         void on_asset_changed(
             const std::filesystem::path& watched_path,
             const FileWatchChange& change);
@@ -307,7 +308,7 @@ namespace tbx
 
         template <typename TAsset>
             requires std::derived_from<TAsset, Asset>
-        static void update_asset_stream_state(Record<TAsset>& record);
+        static std::optional<Result> update_asset_stream_state(Record<TAsset>& record);
 
         template <typename TAsset>
             requires std::derived_from<TAsset, Asset>

--- a/engine/include/tbx/systems/assets/manager.inl
+++ b/engine/include/tbx/systems/assets/manager.inl
@@ -6,7 +6,10 @@ namespace tbx
     struct AssetManager::StoreReloadResult
     {
         bool attempted = false;
+        bool pending = false;
         Result result = {};
+        std::string normalized_path = {};
+        Uuid asset_id = {};
         uint64 revision = 0U;
     };
 
@@ -14,6 +17,7 @@ namespace tbx
     {
         virtual ~IStore() = default;
         virtual std::string_view get_asset_type_name() const = 0;
+        virtual void collect_completed_reloads(std::vector<StoreReloadResult>& reload_results) = 0;
         virtual void erase(Uuid asset_id) = 0;
         virtual StoreReloadResult reload(
             const AssetRegistryEntry& entry,
@@ -36,6 +40,8 @@ namespace tbx
         std::chrono::steady_clock::time_point last_access = {};
         Uuid asset_id = {};
         std::shared_future<Result> pending_load = {};
+        std::shared_ptr<TAsset> pending_reload_asset = {};
+        std::optional<Result> completed_reload_result = std::nullopt;
         AssetLoadParameters<TAsset> load_parameters = {};
         bool has_load_parameters = false;
         uint64 revision = 0U;
@@ -57,6 +63,28 @@ namespace tbx
             return typeid(TAsset).name();
         }
 
+        void collect_completed_reloads(std::vector<StoreReloadResult>& reload_results) override
+        {
+            for (auto& entry : records)
+            {
+                auto& record = entry.second;
+                static_cast<void>(update_asset_stream_state(record));
+                if (!record.completed_reload_result.has_value())
+                    continue;
+
+                reload_results.push_back(
+                    StoreReloadResult {
+                        .attempted = true,
+                        .pending = false,
+                        .result = std::move(*record.completed_reload_result),
+                        .normalized_path = record.normalized_path,
+                        .asset_id = record.asset_id,
+                        .revision = record.revision,
+                    });
+                record.completed_reload_result = std::nullopt;
+            }
+        }
+
         StoreReloadResult reload(
             const AssetRegistryEntry& entry,
             const std::chrono::steady_clock::time_point timestamp,
@@ -73,7 +101,19 @@ namespace tbx
                                                          : AssetLoadParameters<TAsset> {};
             auto promise =
                 serialization_registry.read_async<TAsset>(entry.resolved_path, parameters);
-            auto result = Result(promise.asset != nullptr, "Asset reload failed.");
+            auto result = Result(promise.asset != nullptr, promise.asset ? "" : "Asset reload failed.");
+            if (!result.succeeded())
+            {
+                return {
+                    .attempted = true,
+                    .pending = false,
+                    .result = result,
+                    .normalized_path = record.normalized_path,
+                    .asset_id = record.asset_id,
+                    .revision = record.revision,
+                };
+            }
+
             if (promise.promise.valid()
                 && promise.promise.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
             {
@@ -84,38 +124,51 @@ namespace tbx
                         false,
                         read_result.get_report().empty() ? std::string("Asset reload failed.")
                                                          : read_result.get_report());
+                    return {
+                        .attempted = true,
+                        .pending = false,
+                        .result = result,
+                        .normalized_path = record.normalized_path,
+                        .asset_id = record.asset_id,
+                        .revision = record.revision,
+                    };
                 }
-                else if (promise.asset)
-                {
-                    result = Result(true, read_result.get_report());
-                }
-            }
-            // Keep the existing record intact when a hot reload fails.
-            if (!result.succeeded())
-            {
+
+                populate_loaded_asset_data<TAsset>(promise.asset);
+                promise.asset->id = entry.asset_id;
+                record.asset = std::move(promise.asset);
+                record.pending_load = {};
+                record.pending_reload_asset = {};
+                record.load_parameters = parameters;
+                record.has_load_parameters = true;
+                record.stream_state = AssetStreamState::LOADED;
+                record.last_access = timestamp;
+                record.revision += 1U;
+
                 return {
                     .attempted = true,
-                    .result = result,
+                    .pending = false,
+                    .result = Result(true, read_result.get_report()),
+                    .normalized_path = record.normalized_path,
+                    .asset_id = record.asset_id,
                     .revision = record.revision,
                 };
             }
 
-            populate_loaded_asset_data<TAsset>(promise.asset);
-            if (promise.asset)
-                promise.asset->id = entry.asset_id;
-            record.asset = std::move(promise.asset);
+            // The current asset stays visible until async reload proves the replacement is valid.
             record.pending_load = promise.promise;
+            record.pending_reload_asset = std::move(promise.asset);
             record.load_parameters = parameters;
             record.has_load_parameters = true;
-            record.stream_state =
-                record.asset ? AssetStreamState::LOADING : AssetStreamState::UNLOADED;
+            record.stream_state = AssetStreamState::LOADING;
             record.last_access = timestamp;
-            update_asset_stream_state(record);
-            record.revision += 1U;
 
             return {
                 .attempted = true,
-                .result = result,
+                .pending = true,
+                .result = Result(false, "Asset reload is pending."),
+                .normalized_path = record.normalized_path,
+                .asset_id = record.asset_id,
                 .revision = record.revision,
             };
         }
@@ -136,6 +189,9 @@ namespace tbx
                     continue;
 
                 record.asset.reset();
+                record.pending_reload_asset.reset();
+                record.completed_reload_result = std::nullopt;
+                record.pending_load = {};
                 record.stream_state = AssetStreamState::UNLOADED;
                 unloaded_count += 1U;
             }
@@ -206,23 +262,48 @@ namespace tbx
 
     template <typename TAsset>
         requires std::derived_from<TAsset, Asset>
-    void AssetManager::update_asset_stream_state(Record<TAsset>& record)
+    std::optional<Result> AssetManager::update_asset_stream_state(Record<TAsset>& record)
     {
         if (record.stream_state != AssetStreamState::LOADING)
         {
-            return;
+            return std::nullopt;
         }
         if (!record.pending_load.valid())
         {
-            return;
+            return std::nullopt;
         }
         using namespace std::chrono_literals;
         if (record.pending_load.wait_for(0s) == std::future_status::ready)
         {
+            const Result load_result = record.pending_load.get();
+            record.pending_load = {};
+
+            const bool was_reload = record.pending_reload_asset != nullptr;
+            if (was_reload)
+            {
+                if (load_result.succeeded())
+                {
+                    populate_loaded_asset_data<TAsset>(record.pending_reload_asset);
+                    record.pending_reload_asset->id = record.asset_id;
+                    record.asset = std::move(record.pending_reload_asset);
+                    record.revision += 1U;
+                }
+                else
+                {
+                    record.pending_reload_asset.reset();
+                }
+                record.completed_reload_result = load_result;
+            }
+            else if (!load_result.succeeded())
+            {
+                record.asset.reset();
+            }
+
             record.stream_state =
                 record.asset ? AssetStreamState::LOADED : AssetStreamState::UNLOADED;
-            record.pending_load = {};
+            return load_result;
         }
+        return std::nullopt;
     }
 
     template <typename TAsset>
@@ -593,6 +674,9 @@ namespace tbx
             asset_record.asset_id,
             typeid(TAsset).name());
         asset_record.asset.reset();
+        asset_record.pending_reload_asset.reset();
+        asset_record.completed_reload_result = std::nullopt;
+        asset_record.pending_load = {};
         asset_record.stream_state = AssetStreamState::UNLOADED;
         return true;
     }
@@ -637,7 +721,7 @@ namespace tbx
                 entry.normalized_path,
                 entry.asset_id,
                 typeid(TAsset).name());
-            if (!reload_result.result.succeeded())
+            if (!reload_result.pending && !reload_result.result.succeeded())
             {
                 TBX_TRACE_WARNING(
                     "Failed to reload asset: '{}' (id={}, type={})",
@@ -646,6 +730,6 @@ namespace tbx
                     typeid(TAsset).name());
             }
         }
-        return reload_result.attempted && reload_result.result.succeeded();
+        return reload_result.attempted && !reload_result.pending && reload_result.result.succeeded();
     }
 }

--- a/engine/include/tbx/systems/physics/physics.h
+++ b/engine/include/tbx/systems/physics/physics.h
@@ -6,6 +6,7 @@
 #include "tbx/systems/physics/settings.h"
 #include "tbx/types/assets/world.h"
 #include "tbx/types/raycast.h"
+#include <memory>
 
 namespace tbx
 {
@@ -52,6 +53,12 @@ namespace tbx
 
       private:
         struct EntityRecord;
+        struct EntityRecordDeleter
+        {
+            void operator()(EntityRecord* record) const noexcept;
+        };
+        using EntityRecordPtr = std::unique_ptr<EntityRecord, EntityRecordDeleter>;
+
         void destroy_record(EntityRecord& record);
 
       private:
@@ -59,7 +66,7 @@ namespace tbx
         std::weak_ptr<AssetManager> _asset_manager = {};
         std::weak_ptr<AssetReloadQueue> _reload_queue = {};
         std::weak_ptr<WorldManager> _world_manager = {};
-        std::unordered_map<Uuid, EntityRecord> _records_by_entity = {};
+        std::unordered_map<Uuid, EntityRecordPtr> _records_by_entity = {};
         std::unordered_map<uint64, Uuid> _entity_by_rigidbody_handle = {};
         std::unordered_map<Uuid, std::unordered_set<Uuid>> _overlap_entities_by_trigger = {};
         std::unordered_set<Uuid> _pending_model_reloads = {};

--- a/engine/src/systems/assets/asset_manager.cpp
+++ b/engine/src/systems/assets/asset_manager.cpp
@@ -66,13 +66,19 @@ namespace tbx
     void AssetManager::update(const DeltaTime& dt)
     {
         auto should_unload = false;
+        auto completed_reloads = std::vector<StoreReloadResult>();
         {
             std::lock_guard lock(_mutex);
             _unload_elapsed_seconds += dt.seconds;
             should_unload = _unload_elapsed_seconds >= ASSET_UNLOAD_INTERVAL_SECONDS;
             if (should_unload)
                 _unload_elapsed_seconds = 0.0;
+
+            for (auto& store : _stores)
+                store.second->collect_completed_reloads(completed_reloads);
         }
+
+        dispatch_reload_events(completed_reloads);
 
         if (!should_unload)
             return;
@@ -250,6 +256,26 @@ namespace tbx
         return _serialization_registry;
     }
 
+    void AssetManager::dispatch_reload_events(
+        const std::vector<StoreReloadResult>& reload_results) const
+    {
+        const auto dispatcher = _dispatcher.lock();
+        if (!dispatcher)
+            return;
+
+        for (const auto& reload_result : reload_results)
+        {
+            if (!reload_result.attempted || reload_result.pending)
+                continue;
+
+            dispatcher->post<AssetReloadedEvent>(
+                Handle(reload_result.normalized_path, reload_result.asset_id),
+                reload_result.result.succeeded(),
+                reload_result.revision,
+                reload_result.result.get_report());
+        }
+    }
+
     void AssetManager::remove_directory(const std::filesystem::path& path)
     {
         if (path.empty())
@@ -373,6 +399,7 @@ namespace tbx
                     pending_event_type = PendingAssetEventType::MODIFIED;
 
                     auto reload_result = StoreReloadResult();
+                    auto has_pending_reload = false;
                     if (registry_entry.asset_id.is_valid())
                     {
                         const auto serialization_registry = lock_serialization_registry();
@@ -394,6 +421,12 @@ namespace tbx
                                 registry_entry.normalized_path,
                                 registry_entry.asset_id,
                                 type_name);
+                            if (store_reload_result.pending)
+                            {
+                                has_pending_reload = true;
+                                continue;
+                            }
+
                             if (!store_reload_result.result.succeeded())
                             {
                                 TBX_TRACE_WARNING(
@@ -417,7 +450,7 @@ namespace tbx
                                 reload_result.result = store_reload_result.result;
                         }
 
-                        if (!reload_result.attempted)
+                        if (!reload_result.attempted && !has_pending_reload)
                         {
                             auto polymorphic_revision =
                                 _polymorphic_asset_revisions.find(registry_entry.asset_id);

--- a/engine/src/systems/assets/serialization_registry.cpp
+++ b/engine/src/systems/assets/serialization_registry.cpp
@@ -69,14 +69,19 @@ namespace tbx
         }
 
         // Rename-hardened references resolve by UUID, but construction needs the registered C++
-        // asset type. A meta "type" field is preferred; the filename fallback preserves existing
-        // asset conventions for simple cases.
+        // asset type. Only explicitly polymorphic meta files use "type" as that discriminator so
+        // asset-specific metadata, such as shader stages, can keep their existing key names.
         auto type_name = std::string();
         if (meta_data.has_value())
         {
             auto meta_json = Json();
-            if (JsonParser::try_parse(*meta_data, meta_json))
+            auto is_polymorphic = false;
+            if (JsonParser::try_parse(*meta_data, meta_json)
+                && JsonParser::try_get(meta_json, "polymorphic", is_polymorphic)
+                && is_polymorphic)
+            {
                 static_cast<void>(JsonParser::try_get(meta_json, "type", type_name));
+            }
         }
         if (type_name.empty())
             type_name = make_serializable_type_name(asset_path.stem().string());

--- a/engine/src/systems/physics/physics.cpp
+++ b/engine/src/systems/physics/physics.cpp
@@ -421,6 +421,11 @@ namespace tbx
         bool is_trigger_only = false;
     };
 
+    void Physics::EntityRecordDeleter::operator()(EntityRecord* record) const noexcept
+    {
+        delete record;
+    }
+
     Physics::Physics(
         std::weak_ptr<IPhysicsBackend> backend,
         std::weak_ptr<AssetManager> asset_manager,
@@ -480,7 +485,7 @@ namespace tbx
         {
             if (const auto record_it = _records_by_entity.find(raycast_query.ignored_entity_id);
                 record_it != _records_by_entity.end())
-                ignored_rigidbody = record_it->second.rigidbody;
+                ignored_rigidbody = record_it->second->rigidbody;
         }
 
         auto backend_hit = PhysicsRaycastHit {};
@@ -538,7 +543,7 @@ namespace tbx
     void Physics::clear_resources()
     {
         for (auto& record_entry : _records_by_entity)
-            destroy_record(record_entry.second);
+            destroy_record(*record_entry.second);
 
         _records_by_entity.clear();
         _entity_by_rigidbody_handle.clear();
@@ -612,7 +617,7 @@ namespace tbx
             {
                 auto overlapped_rigidbodies = std::vector<PhysicsRigidbodyHandle> {};
                 backend->get_rigidbody_overlaps(
-                    record_it->second.rigidbody,
+                    record_it->second->rigidbody,
                     overlapped_rigidbodies);
                 current_overlaps.reserve(overlapped_rigidbodies.size());
                 for (const PhysicsRigidbodyHandle overlapped_rigidbody : overlapped_rigidbodies)
@@ -713,15 +718,15 @@ namespace tbx
 
             auto record_it = _records_by_entity.find(entity_id);
             if (record_it != _records_by_entity.end()
-                && (record_it->second.is_physics_driven != is_physics_driven
-                    || record_it->second.is_trigger_only != is_trigger_only
+                && (record_it->second->is_physics_driven != is_physics_driven
+                    || record_it->second->is_trigger_only != is_trigger_only
                     || (entity.has_component<StaticMesh>()
                         && _pending_model_reloads.contains(
                             entity.get_component<StaticMesh>().handle.id))
-                    || (entity.has_component<MeshCollider>() && record_it->second.has_last_transform
-                        && has_scale_changed(world_transform.scale, record_it->second.last_scale))))
+                    || (entity.has_component<MeshCollider>() && record_it->second->has_last_transform
+                        && has_scale_changed(world_transform.scale, record_it->second->last_scale))))
             {
-                destroy_record(record_it->second);
+                destroy_record(*record_it->second);
                 _records_by_entity.erase(record_it);
                 record_it = _records_by_entity.end();
             }
@@ -751,7 +756,8 @@ namespace tbx
                     continue;
                 }
 
-                auto& record = _records_by_entity[entity_id];
+                auto record_ptr = EntityRecordPtr(new EntityRecord());
+                auto& record = *record_ptr;
                 record.collider = collider;
                 record.rigidbody = rigidbody_handle;
                 record.last_position = world_transform.position;
@@ -760,11 +766,12 @@ namespace tbx
                 record.has_last_transform = true;
                 record.is_physics_driven = is_physics_driven;
                 record.is_trigger_only = is_trigger_only;
+                _records_by_entity[entity_id] = std::move(record_ptr);
                 _entity_by_rigidbody_handle[rigidbody_handle.value] = entity_id;
                 continue;
             }
 
-            auto& record = record_it->second;
+            auto& record = *record_it->second;
             const bool transform_is_dirty = record.has_last_transform
                                             && has_transform_changed(
                                                 world_transform,
@@ -825,7 +832,7 @@ namespace tbx
             if (record_it == _records_by_entity.end())
                 continue;
 
-            destroy_record(record_it->second);
+            destroy_record(*record_it->second);
             _records_by_entity.erase(record_it);
         }
     }
@@ -839,7 +846,7 @@ namespace tbx
         for (auto& record_entry : _records_by_entity)
         {
             const Uuid& entity_id = record_entry.first;
-            auto& record = record_entry.second;
+            auto& record = *record_entry.second;
 
             if (!world.has<Transform>(entity_id))
                 continue;

--- a/engine/tests/assets/asset_manager_tests.cpp
+++ b/engine/tests/assets/asset_manager_tests.cpp
@@ -22,6 +22,10 @@ namespace tbx
         std::filesystem::path resolved_include_path = {};
     };
 
+    struct PolymorphicFallbackAsset : Asset
+    {
+    };
+
     struct [[serializable]] [[version(1U)]] MacroOnlyAsset : Asset
     {
         [[prop]]
@@ -316,6 +320,9 @@ namespace tbx::tests::assets
         std::filesystem::path watched_path = {};
         std::filesystem::path asset_path = {};
         Handle affected_asset = {};
+        bool reload_succeeded = false;
+        uint64 reload_revision = 0U;
+        std::string reload_report = {};
     };
 
     class CapturingAssetEventDispatcher final : public IMessageDispatcher
@@ -433,6 +440,9 @@ namespace tbx::tests::assets
                             .watched_path = {},
                             .asset_path = {},
                             .affected_asset = reloaded->get().affected_asset,
+                            .reload_succeeded = reloaded->get().succeeded,
+                            .reload_revision = reloaded->get().revision,
+                            .reload_report = reloaded->get().report,
                         });
                 }
             }
@@ -674,6 +684,63 @@ namespace tbx::tests::assets
         EXPECT_TRUE(JsonParser::try_get(written_json, "value", written_value));
         EXPECT_EQ(written_label, "written");
         EXPECT_EQ(written_value, 77);
+    }
+
+
+    TEST(serialization_registry, polymorphic_meta_type_selects_registered_asset_type_when_flagged)
+    {
+        // Arrange
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text("content/not_matching.custom", R"({ "label": "source", "value": 42 })");
+        file_ops->set_text(
+            "content/not_matching.custom.meta",
+            R"({ "id": { "value": 50 }, "version": 1, "polymorphic": true, "type": "CustomBodyAsset" })");
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        const auto read = registry.read_registered_asset_result("content/not_matching.custom");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded());
+        ASSERT_NE(read.asset, nullptr);
+        const auto asset = std::dynamic_pointer_cast<CustomBodyAsset>(read.asset);
+        ASSERT_NE(asset, nullptr);
+        EXPECT_EQ(asset->id, Uuid(0x32U));
+        EXPECT_EQ(asset->version, 1U);
+        EXPECT_EQ(asset->label, "source");
+        EXPECT_EQ(asset->value, 42);
+    }
+
+    TEST(serialization_registry, non_polymorphic_meta_ignores_asset_specific_type_field)
+    {
+        // Arrange
+        auto file_ops = std::make_shared<InMemoryFileOps>("/virtual/serialization");
+        file_ops->set_text("content/StageNamedAsset.asset", "");
+        file_ops->set_text(
+            "content/StageNamedAsset.asset.meta",
+            R"({ "id": { "value": 51 }, "version": 1, "type": "fragment" })");
+        register_asset_type_entry(
+            AssetTypeRegistration {
+                .type_name = "stage_named_asset",
+                .type = std::type_index(typeid(PolymorphicFallbackAsset)),
+                .version = 1U,
+                .create_asset = []()
+                {
+                    return std::make_unique<PolymorphicFallbackAsset>();
+                },
+            });
+        auto registry = SerializationRegistry {file_ops};
+
+        // Act
+        const auto read = registry.read_registered_asset_result("content/StageNamedAsset.asset");
+
+        // Assert
+        ASSERT_TRUE(read.result.succeeded());
+        ASSERT_NE(read.asset, nullptr);
+        const auto asset = std::dynamic_pointer_cast<PolymorphicFallbackAsset>(read.asset);
+        ASSERT_NE(asset, nullptr);
+        EXPECT_EQ(asset->id, Uuid(0x33U));
+        EXPECT_EQ(asset->version, 1U);
     }
 
     TEST(serialization_registry, registered_loader_and_writer_override_custom_asset_defaults)
@@ -977,6 +1044,83 @@ namespace tbx::tests::assets
         AssetUsage usage = manager.get_usage<TestAsset>(handle);
         EXPECT_EQ(usage.stream_state, AssetStreamState::LOADED);
         EXPECT_EQ(streamed_in.asset->value, 99);
+    }
+
+
+    TEST(asset_manager, async_reload_swaps_asset_after_success)
+    {
+        // Arrange
+        std::filesystem::path working_directory = "/virtual/asset_manager";
+        auto dispatcher = std::make_shared<CapturingAssetEventDispatcher>();
+        AssetManager manager(
+            dispatcher,
+            get_test_serialization_registry(),
+            working_directory);
+        register_test_asset_loader(*get_test_serialization_registry());
+        Handle handle("async_reload_success.asset");
+        TestAssetLoadParameters parameters = {.value = 5};
+        reset_test_asset_loader_state();
+        auto original_asset = manager.load<TestAsset>(handle, parameters);
+        ASSERT_NE(original_asset, nullptr);
+        const auto before_usage = manager.get_usage<TestAsset>(handle);
+
+        // Act
+        auto& loader_state = get_test_asset_loader_state();
+        loader_state.use_async = true;
+        const bool completed_reload = manager.reload<TestAsset>(handle);
+        ASSERT_FALSE(completed_reload);
+        EXPECT_TRUE(dispatcher->get_reloaded_events().empty());
+        ASSERT_NE(loader_state.asset, nullptr);
+        loader_state.asset->value = 99;
+        auto success = Result();
+        success.flag_success();
+        loader_state.completion->set_value(success);
+        manager.update(DeltaTime());
+        const auto loading_usage = manager.get_usage<TestAsset>(handle);
+        auto reloaded_asset = manager.load<TestAsset>(handle, parameters);
+        const auto reloaded_events = dispatcher->get_reloaded_events();
+
+        // Assert
+        ASSERT_NE(reloaded_asset, nullptr);
+        EXPECT_NE(reloaded_asset, original_asset);
+        EXPECT_EQ(reloaded_asset->value, 99);
+        EXPECT_EQ(loading_usage.stream_state, AssetStreamState::LOADED);
+        EXPECT_EQ(loading_usage.revision, before_usage.revision + 1U);
+        ASSERT_EQ(reloaded_events.size(), 1U);
+        EXPECT_TRUE(reloaded_events[0].reload_succeeded);
+        EXPECT_EQ(reloaded_events[0].reload_revision, before_usage.revision + 1U);
+    }
+
+    TEST(asset_manager, async_reload_failure_preserves_existing_asset)
+    {
+        // Arrange
+        std::filesystem::path working_directory = "/virtual/asset_manager";
+        AssetManager manager = make_manager(working_directory);
+        Handle handle("async_reload_failure.asset");
+        TestAssetLoadParameters parameters = {.value = 7};
+        reset_test_asset_loader_state();
+        auto original_asset = manager.load<TestAsset>(handle, parameters);
+        ASSERT_NE(original_asset, nullptr);
+        const auto before_usage = manager.get_usage<TestAsset>(handle);
+
+        // Act
+        auto& loader_state = get_test_asset_loader_state();
+        loader_state.use_async = true;
+        const bool completed_reload = manager.reload<TestAsset>(handle);
+        ASSERT_FALSE(completed_reload);
+        ASSERT_NE(loader_state.asset, nullptr);
+        loader_state.asset->value = 99;
+        auto failure = Result();
+        failure.flag_failure("reload failed");
+        loader_state.completion->set_value(failure);
+        const auto after_usage = manager.get_usage<TestAsset>(handle);
+        auto loaded_asset = manager.load<TestAsset>(handle, parameters);
+
+        // Assert
+        EXPECT_EQ(loaded_asset, original_asset);
+        EXPECT_EQ(loaded_asset->value, 7);
+        EXPECT_EQ(after_usage.stream_state, AssetStreamState::LOADED);
+        EXPECT_EQ(after_usage.revision, before_usage.revision);
     }
 
     TEST(asset_manager, unloads_unreferenced_assets)


### PR DESCRIPTION
### Motivation
- Improve asset hot-reload behavior to keep the existing asset visible while an async reload completes and notify listeners when reloads finish.
- Allow meta files to opt into polymorphic type selection so registered asset types can be enforced for polymorphic assets.
- Make `Physics::EntityRecord` ownership explicit to simplify lifetime management and avoid accidental copies.

### Description
- Asset system: introduce `StoreReloadResult.pending`, `normalized_path`, and `asset_id` and add `IStore::collect_completed_reloads` to collect completed async reloads.
- Record/store changes: add `pending_reload_asset` and `completed_reload_result` to `Record<TAsset>` and change `Store<TAsset>::reload` to keep the current asset visible until async reload validates and to return richer reload status; successful async reload swaps the asset and increments `revision`.
- Update `update_asset_stream_state` to return an optional `Result`, consume completed `pending_load` futures, and populate `completed_reload_result` for later dispatch.
- AssetManager: collect completed reloads from all stores during `update` and dispatch `AssetReloadedEvent` messages via the new `dispatch_reload_events` helper; adjust `reload` to reflect pending reloads.
- SerializationRegistry: when a meta JSON contains `"polymorphic": true`, allow `"type"` to override the asset type lookup so explicitly polymorphic meta files can select a registered type.
- Physics: change `_records_by_entity` to store `std::unique_ptr<EntityRecord>` with a custom `EntityRecordDeleter`, update usages to dereference the pointer, and add missing `#include <memory>`.
- Tests: extend `CapturingAssetEventDispatcher` to capture reload result fields and add tests exercising polymorphic meta type handling and async reload behavior: `polymorphic_meta_type_selects_registered_asset_type_when_flagged`, `non_polymorphic_meta_ignores_asset_specific_type_field`, `async_reload_swaps_asset_after_success`, and `async_reload_failure_preserves_existing_asset`.

### Testing
- Ran modified unit tests in `engine/tests/assets` including the new tests for `serialization_registry` and `asset_manager`; all added and updated tests passed locally.
- Executed the asset manager reload-related tests (`async_reload_swaps_asset_after_success`, `async_reload_failure_preserves_existing_asset`) and they succeeded.
- Verified existing asset serialization tests that exercise loader/writer behavior still pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f2717e0a0832785ba6fc6259895dc)